### PR TITLE
Add public Kalshi market data tool

### DIFF
--- a/workflow-python/app/tools/kalshi_market_data.py
+++ b/workflow-python/app/tools/kalshi_market_data.py
@@ -1,0 +1,269 @@
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any, Literal
+
+import httpx
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field
+
+from app.contracts.workflow import BoundedLevel, NonEmptyString, Probability, Warning
+from app.core.errors import ErrorCode, WorkflowError
+
+KALSHI_PUBLIC_API_BASE_URL = "https://api.elections.kalshi.com/trade-api/v2"
+THIN_TOP_OF_BOOK_CONTRACTS = Decimal("20")
+THIN_VOLUME_CONTRACTS = Decimal("100")
+
+
+class MarketMetadata(BaseModel):
+    ticker: NonEmptyString
+    title: NonEmptyString
+    subtitle: str | None = None
+    url: AnyUrl | None = None
+    status: Literal["open", "closed", "settled", "unknown"]
+    close_time: datetime | None = Field(default=None, alias="closeTime")
+    settlement_source: str | None = Field(default=None, alias="settlementSource")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class PriceContext(BaseModel):
+    yes_bid: Probability | None = Field(default=None, alias="yesBid")
+    yes_ask: Probability | None = Field(default=None, alias="yesAsk")
+    last_price: Probability | None = Field(default=None, alias="lastPrice")
+    spread: Probability | None = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class OrderbookLevel(BaseModel):
+    price: Probability
+    contracts: float = Field(ge=0)
+
+
+class OrderbookSummary(BaseModel):
+    yes_bid_levels: int = Field(alias="yesBidLevels", ge=0)
+    no_bid_levels: int = Field(alias="noBidLevels", ge=0)
+    best_yes_bid: OrderbookLevel | None = Field(default=None, alias="bestYesBid")
+    best_no_bid: OrderbookLevel | None = Field(default=None, alias="bestNoBid")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class PublicMarketData(BaseModel):
+    market: MarketMetadata
+    implied_probability: Probability = Field(alias="impliedProbability")
+    prices: PriceContext
+    volume: float | None = Field(default=None, ge=0)
+    open_interest: float | None = Field(default=None, ge=0, alias="openInterest")
+    orderbook: OrderbookSummary | None = None
+    warnings: list[Warning]
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class KalshiPublicMarketDataTool:
+    def __init__(
+        self,
+        base_url: str = KALSHI_PUBLIC_API_BASE_URL,
+        timeout_seconds: float = 10,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    async def fetch(self, ticker: str, *, now: datetime | None = None) -> PublicMarketData:
+        normalized_ticker = ticker.strip().upper()
+        if not normalized_ticker:
+            raise WorkflowError(ErrorCode.INVALID_INPUT, "Market ticker is required.", status_code=422)
+
+        async with httpx.AsyncClient(
+            base_url=self._base_url, timeout=self._timeout_seconds, transport=self._transport
+        ) as client:
+            market_payload = await self._get_json(client, f"/markets/{normalized_ticker}")
+            orderbook_payload = await self._get_optional_json(client, f"/markets/{normalized_ticker}/orderbook")
+
+        market = market_payload.get("market", market_payload)
+        if not isinstance(market, dict):
+            raise WorkflowError(
+                ErrorCode.MARKET_DATA_UNAVAILABLE, "Kalshi market response was malformed.", status_code=502
+            )
+
+        orderbook = _summarize_orderbook(orderbook_payload)
+        prices = _price_context(market)
+        close_time = _parse_datetime(market.get("close_time"))
+        volume = _fixed_point_count(market.get("volume_fp") or market.get("volume"))
+        open_interest = _fixed_point_count(market.get("open_interest_fp") or market.get("open_interest"))
+        implied_probability = _implied_probability(prices)
+        warnings = _warnings(market, prices, orderbook, close_time, volume, now or datetime.now(UTC))
+
+        return PublicMarketData(
+            market=MarketMetadata(
+                ticker=str(market.get("ticker") or normalized_ticker),
+                title=str(market.get("title") or market.get("yes_sub_title") or normalized_ticker),
+                subtitle=market.get("subtitle") or market.get("yes_sub_title"),
+                url=f"https://kalshi.com/markets/{normalized_ticker}",
+                status=_status(market.get("status")),
+                closeTime=close_time,
+                settlementSource=market.get("rules_primary"),
+            ),
+            implied_probability=implied_probability,
+            prices=prices,
+            volume=float(volume) if volume is not None else None,
+            openInterest=float(open_interest) if open_interest is not None else None,
+            orderbook=orderbook,
+            warnings=warnings,
+        )
+
+    async def _get_json(self, client: httpx.AsyncClient, path: str) -> dict[str, Any]:
+        try:
+            response = await client.get(path)
+            response.raise_for_status()
+            payload = response.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            raise WorkflowError(
+                ErrorCode.MARKET_DATA_UNAVAILABLE, "Kalshi market data was unavailable.", status_code=502
+            ) from exc
+        if not isinstance(payload, dict):
+            raise WorkflowError(
+                ErrorCode.MARKET_DATA_UNAVAILABLE, "Kalshi market response was malformed.", status_code=502
+            )
+        return payload
+
+    async def _get_optional_json(self, client: httpx.AsyncClient, path: str) -> dict[str, Any] | None:
+        try:
+            return await self._get_json(client, path)
+        except WorkflowError:
+            return None
+
+
+def _price_context(market: dict[str, Any]) -> PriceContext:
+    yes_bid = _probability(market.get("yes_bid_dollars") or market.get("yes_bid"))
+    yes_ask = _probability(market.get("yes_ask_dollars") or market.get("yes_ask"))
+    last_price = _probability(market.get("last_price_dollars") or market.get("last_price"))
+    spread = yes_ask - yes_bid if yes_bid is not None and yes_ask is not None else None
+    return PriceContext(yesBid=yes_bid, yesAsk=yes_ask, lastPrice=last_price, spread=spread)
+
+
+def _implied_probability(prices: PriceContext) -> float:
+    if prices.yes_bid is not None and prices.yes_ask is not None:
+        return (prices.yes_bid + prices.yes_ask) / 2
+    if prices.last_price is not None:
+        return prices.last_price
+    if prices.yes_bid is not None:
+        return prices.yes_bid
+    if prices.yes_ask is not None:
+        return prices.yes_ask
+    raise WorkflowError(
+        ErrorCode.MARKET_DATA_UNAVAILABLE, "Kalshi market did not include usable price data.", status_code=502
+    )
+
+
+def _summarize_orderbook(payload: dict[str, Any] | None) -> OrderbookSummary | None:
+    if not payload:
+        return None
+    orderbook = payload.get("orderbook_fp") or payload.get("orderbook") or payload
+    if not isinstance(orderbook, dict):
+        return None
+    yes_levels = _levels(orderbook.get("yes_dollars") or orderbook.get("yes") or [])
+    no_levels = _levels(orderbook.get("no_dollars") or orderbook.get("no") or [])
+    return OrderbookSummary(
+        yes_bid_levels=len(yes_levels),
+        no_bid_levels=len(no_levels),
+        bestYesBid=yes_levels[-1] if yes_levels else None,
+        bestNoBid=no_levels[-1] if no_levels else None,
+    )
+
+
+def _levels(raw_levels: Any) -> list[OrderbookLevel]:
+    if not isinstance(raw_levels, list):
+        return []
+    levels = []
+    for raw_level in raw_levels:
+        if not isinstance(raw_level, list | tuple) or len(raw_level) < 2:
+            continue
+        price = _probability(raw_level[0])
+        contracts = _fixed_point_count(raw_level[1])
+        if price is None or contracts is None:
+            continue
+        levels.append(OrderbookLevel(price=price, contracts=float(contracts)))
+    return sorted(levels, key=lambda level: level.price)
+
+
+def _warnings(
+    market: dict[str, Any],
+    prices: PriceContext,
+    orderbook: OrderbookSummary | None,
+    close_time: datetime | None,
+    volume: Decimal | None,
+    now: datetime,
+) -> list[Warning]:
+    warnings: list[Warning] = []
+    top_sizes = [
+        _fixed_point_count(market.get("yes_bid_size_fp")),
+        _fixed_point_count(market.get("yes_ask_size_fp")),
+    ]
+    thin_top = any(size is not None and size < THIN_TOP_OF_BOOK_CONTRACTS for size in top_sizes)
+    thin_volume = volume is not None and volume < THIN_VOLUME_CONTRACTS
+    missing_book = orderbook is None or (orderbook.yes_bid_levels == 0 and orderbook.no_bid_levels == 0)
+
+    if missing_book or thin_top or thin_volume:
+        warnings.append(
+            Warning(
+                kind="liquidity",
+                message="Kalshi market has thin or missing orderbook context; treat the implied probability as noisy.",
+                severity=BoundedLevel.MEDIUM,
+            )
+        )
+    if prices.spread is not None and prices.spread >= 0.1:
+        warnings.append(
+            Warning(kind="liquidity", message="Kalshi best bid/ask spread is wide.", severity=BoundedLevel.MEDIUM)
+        )
+    if _status(market.get("status")) != "open" or (close_time is not None and close_time <= now):
+        warnings.append(
+            Warning(
+                kind="staleness",
+                message="Kalshi market is not currently open or has already reached close time.",
+                severity=BoundedLevel.HIGH,
+            )
+        )
+    return warnings
+
+
+def _status(raw_status: Any) -> Literal["open", "closed", "settled", "unknown"]:
+    status = str(raw_status or "").lower()
+    if status in {"active", "open"}:
+        return "open"
+    if status in {"closed", "inactive"}:
+        return "closed"
+    if status in {"determined", "settled", "finalized"}:
+        return "settled"
+    return "unknown"
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _probability(value: Any) -> float | None:
+    decimal_value = _decimal(value)
+    if decimal_value is None:
+        return None
+    if decimal_value > 1:
+        decimal_value = decimal_value / Decimal(100)
+    return float(decimal_value)
+
+
+def _fixed_point_count(value: Any) -> Decimal | None:
+    return _decimal(value)
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if value is None or value == "":
+        return None
+    try:
+        return Decimal(str(value))
+    except InvalidOperation:
+        return None

--- a/workflow-python/app/tools/kalshi_market_data.py
+++ b/workflow-python/app/tools/kalshi_market_data.py
@@ -140,7 +140,8 @@ def _price_context(market: dict[str, Any]) -> PriceContext:
     yes_bid = _probability(market.get("yes_bid_dollars") or market.get("yes_bid"))
     yes_ask = _probability(market.get("yes_ask_dollars") or market.get("yes_ask"))
     last_price = _probability(market.get("last_price_dollars") or market.get("last_price"))
-    spread = yes_ask - yes_bid if yes_bid is not None and yes_ask is not None else None
+    raw_spread = yes_ask - yes_bid if yes_bid is not None and yes_ask is not None else None
+    spread = raw_spread if raw_spread is None or raw_spread >= 0 else None
     return PriceContext(yesBid=yes_bid, yesAsk=yes_ask, lastPrice=last_price, spread=spread)
 
 
@@ -217,6 +218,14 @@ def _warnings(
     if prices.spread is not None and prices.spread >= 0.1:
         warnings.append(
             Warning(kind="liquidity", message="Kalshi best bid/ask spread is wide.", severity=BoundedLevel.MEDIUM)
+        )
+    if prices.yes_bid is not None and prices.yes_ask is not None and prices.yes_bid > prices.yes_ask:
+        warnings.append(
+            Warning(
+                kind="liquidity",
+                message="Kalshi best bid is above best ask; quote may be transiently crossed.",
+                severity=BoundedLevel.MEDIUM,
+            )
         )
     if _status(market.get("status")) != "open" or (close_time is not None and close_time <= now):
         warnings.append(

--- a/workflow-python/tests/test_kalshi_market_data.py
+++ b/workflow-python/tests/test_kalshi_market_data.py
@@ -111,6 +111,22 @@ async def test_thin_liquidity_warning_uses_volume_and_top_of_book() -> None:
 
 
 @pytest.mark.asyncio
+async def test_crossed_quote_does_not_fail_validation_and_warns() -> None:
+    tool, _requests = _tool(
+        {
+            "/markets/KXEXAMPLE-26MAY03-DEMO": _market(yes_bid_dollars="0.6200", yes_ask_dollars="0.5800"),
+            "/markets/KXEXAMPLE-26MAY03-DEMO/orderbook": _orderbook(),
+        }
+    )
+
+    result = await tool.fetch("KXEXAMPLE-26MAY03-DEMO", now=datetime(2026, 5, 3, tzinfo=UTC))
+
+    assert result.implied_probability == 0.6
+    assert result.prices.spread is None
+    assert any(warning.kind == "liquidity" for warning in result.warnings)
+
+
+@pytest.mark.asyncio
 async def test_stale_market_warning_uses_status_and_close_time() -> None:
     tool, _requests = _tool(
         {

--- a/workflow-python/tests/test_kalshi_market_data.py
+++ b/workflow-python/tests/test_kalshi_market_data.py
@@ -1,0 +1,124 @@
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import pytest
+
+from app.tools.kalshi_market_data import KalshiPublicMarketDataTool
+
+
+def _market(**overrides: Any) -> dict[str, Any]:
+    market = {
+        "ticker": "KXEXAMPLE-26MAY03-DEMO",
+        "title": "Will the demo event happen?",
+        "subtitle": "Demo event",
+        "status": "active",
+        "close_time": "2026-05-04T00:00:00Z",
+        "yes_bid_dollars": "0.4200",
+        "yes_ask_dollars": "0.4600",
+        "last_price_dollars": "0.4300",
+        "yes_bid_size_fp": "75.00",
+        "yes_ask_size_fp": "80.00",
+        "volume_fp": "1200.00",
+        "open_interest_fp": "400.00",
+        "rules_primary": "Official source named in market rules.",
+    }
+    market.update(overrides)
+    return {"market": market}
+
+
+def _orderbook(**overrides: Any) -> dict[str, Any]:
+    orderbook = {
+        "yes_dollars": [["0.0100", "200.00"], ["0.4200", "75.00"]],
+        "no_dollars": [["0.0100", "150.00"], ["0.5400", "80.00"]],
+    }
+    orderbook.update(overrides)
+    return {"orderbook_fp": orderbook}
+
+
+def _tool(fixtures: dict[str, dict[str, Any]]) -> tuple[KalshiPublicMarketDataTool, list[httpx.Request]]:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        assert "authorization" not in request.headers
+        assert "/portfolio/" not in request.url.path
+        assert "/orders" not in request.url.path
+        return httpx.Response(200, json=fixtures[request.url.path])
+
+    return KalshiPublicMarketDataTool(base_url="https://kalshi.test", transport=httpx.MockTransport(handler)), requests
+
+
+@pytest.mark.asyncio
+async def test_fetches_public_market_data_with_orderbook_summary() -> None:
+    tool, requests = _tool(
+        {
+            "/markets/KXEXAMPLE-26MAY03-DEMO": _market(),
+            "/markets/KXEXAMPLE-26MAY03-DEMO/orderbook": _orderbook(),
+        }
+    )
+
+    result = await tool.fetch("kxexample-26may03-demo", now=datetime(2026, 5, 3, tzinfo=UTC))
+
+    assert [request.url.path for request in requests] == [
+        "/markets/KXEXAMPLE-26MAY03-DEMO",
+        "/markets/KXEXAMPLE-26MAY03-DEMO/orderbook",
+    ]
+    assert result.market.ticker == "KXEXAMPLE-26MAY03-DEMO"
+    assert result.market.title == "Will the demo event happen?"
+    assert result.market.status == "open"
+    assert result.implied_probability == 0.44
+    assert result.prices.yes_bid == 0.42
+    assert result.prices.yes_ask == 0.46
+    assert result.prices.spread == pytest.approx(0.04)
+    assert result.volume == 1200
+    assert result.open_interest == 400
+    assert result.orderbook is not None
+    assert result.orderbook.yes_bid_levels == 2
+    assert result.orderbook.best_yes_bid is not None
+    assert result.orderbook.best_yes_bid.contracts == 75
+    assert result.warnings == []
+
+
+@pytest.mark.asyncio
+async def test_missing_orderbook_data_does_not_crash_and_warns() -> None:
+    tool, _requests = _tool(
+        {
+            "/markets/KXEXAMPLE-26MAY03-DEMO": _market(),
+            "/markets/KXEXAMPLE-26MAY03-DEMO/orderbook": {"orderbook_fp": {"yes_dollars": [], "no_dollars": []}},
+        }
+    )
+
+    result = await tool.fetch("KXEXAMPLE-26MAY03-DEMO", now=datetime(2026, 5, 3, tzinfo=UTC))
+
+    assert result.orderbook is not None
+    assert result.orderbook.yes_bid_levels == 0
+    assert {warning.kind for warning in result.warnings} == {"liquidity"}
+
+
+@pytest.mark.asyncio
+async def test_thin_liquidity_warning_uses_volume_and_top_of_book() -> None:
+    tool, _requests = _tool(
+        {
+            "/markets/KXEXAMPLE-26MAY03-DEMO": _market(volume_fp="25.00", yes_bid_size_fp="4.00"),
+            "/markets/KXEXAMPLE-26MAY03-DEMO/orderbook": _orderbook(),
+        }
+    )
+
+    result = await tool.fetch("KXEXAMPLE-26MAY03-DEMO", now=datetime(2026, 5, 3, tzinfo=UTC))
+
+    assert any(warning.kind == "liquidity" for warning in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_stale_market_warning_uses_status_and_close_time() -> None:
+    tool, _requests = _tool(
+        {
+            "/markets/KXEXAMPLE-26MAY03-DEMO": _market(status="closed", close_time="2026-05-02T00:00:00Z"),
+            "/markets/KXEXAMPLE-26MAY03-DEMO/orderbook": _orderbook(),
+        }
+    )
+
+    result = await tool.fetch("KXEXAMPLE-26MAY03-DEMO", now=datetime(2026, 5, 3, tzinfo=UTC))
+
+    assert any(warning.kind == "staleness" and warning.severity == "high" for warning in result.warnings)


### PR DESCRIPTION
## Summary
- Adds a public, unauthenticated Kalshi market-data tool for market metadata, price context, implied probability, orderbook summary, and liquidity/staleness warnings.
- Handles missing or empty orderbook responses without crashing and avoids trading, order, portfolio, or credential paths.
- Keeps prior workflow API validation tightening on this branch.

## Tests
- `uv run pytest`
- `uv run ruff check .`
- `uv run mypy .`

Closes #5