### PR TITLE
Add evidence research tool

### DIFF
--- a/workflow-python/app/contracts/workflow.py
+++ b/workflow-python/app/contracts/workflow.py
@@ -73,6 +73,8 @@ class Evidence(BaseModel):
     claim: NonEmptyString
     source_title: NonEmptyString = Field(alias="sourceTitle")
     source_url: AnyUrl | None = Field(default=None, alias="sourceUrl")
+    context: NonEmptyString | None = None
+    source_published_at: datetime | None = Field(default=None, alias="sourcePublishedAt")
     relevance: BoundedLevel
 
     model_config = ConfigDict(populate_by_name=True)

--- a/workflow-python/app/core/config.py
+++ b/workflow-python/app/core/config.py
@@ -7,6 +7,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     app_name: str = "Kalshi Research Workflow API"
     cors_allow_origins: list[str] = Field(default_factory=lambda: ["http://localhost:3000", "http://127.0.0.1:3000"])
+    tavily_api_key: str | None = None
 
     model_config = SettingsConfigDict(env_prefix="WORKFLOW_", env_file=".env", extra="ignore")
 

--- a/workflow-python/app/tools/evidence_research.py
+++ b/workflow-python/app/tools/evidence_research.py
@@ -1,0 +1,162 @@
+from datetime import datetime
+from typing import Any, Protocol
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.contracts.workflow import BoundedLevel, Evidence
+from app.core.errors import ErrorCode, WorkflowError
+
+TAVILY_SEARCH_API_URL = "https://api.tavily.com/search"
+
+
+class EvidenceRequirement(BaseModel):
+    confidence: BoundedLevel
+    min_sources: int = Field(alias="minSources", ge=1)
+    min_relevance: BoundedLevel = Field(alias="minRelevance")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class EvidenceSearchResult(BaseModel):
+    evidence: list[Evidence]
+    requirements: list[EvidenceRequirement]
+
+
+class SearchProvider(Protocol):
+    async def search(self, query: str, *, max_results: int) -> list[dict[str, Any]]: ...
+
+
+class MockSearchProvider:
+    def __init__(self, results: list[dict[str, Any]]) -> None:
+        self._results = results
+
+    async def search(self, query: str, *, max_results: int) -> list[dict[str, Any]]:
+        del query
+        return self._results[:max_results]
+
+
+class TavilySearchProvider:
+    def __init__(
+        self,
+        api_key: str,
+        api_url: str = TAVILY_SEARCH_API_URL,
+        timeout_seconds: float = 20,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._api_key = api_key.strip()
+        self._api_url = api_url
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    async def search(self, query: str, *, max_results: int) -> list[dict[str, Any]]:
+        if not self._api_key:
+            raise WorkflowError(
+                ErrorCode.SEARCH_FAILURE, "Tavily API key is required for live search.", status_code=503
+            )
+
+        async with httpx.AsyncClient(timeout=self._timeout_seconds, transport=self._transport) as client:
+            try:
+                response = await client.post(
+                    self._api_url,
+                    headers={"Authorization": f"Bearer {self._api_key}"},
+                    json={
+                        "query": query,
+                        "search_depth": "basic",
+                        "topic": "news",
+                        "include_answer": False,
+                        "max_results": max_results,
+                    },
+                )
+                response.raise_for_status()
+                payload = response.json()
+            except (httpx.HTTPError, ValueError) as exc:
+                raise WorkflowError(ErrorCode.SEARCH_FAILURE, "Tavily search failed.", status_code=502) from exc
+
+        results = payload.get("results") if isinstance(payload, dict) else None
+        if not isinstance(results, list):
+            raise WorkflowError(ErrorCode.SEARCH_FAILURE, "Tavily search response was malformed.", status_code=502)
+        return [result for result in results if isinstance(result, dict)]
+
+
+class EvidenceResearchTool:
+    def __init__(self, provider: SearchProvider) -> None:
+        self._provider = provider
+
+    async def gather(self, query: str, *, max_results: int = 5) -> EvidenceSearchResult:
+        normalized_query = query.strip()
+        if not normalized_query:
+            raise WorkflowError(ErrorCode.INVALID_INPUT, "Research query is required.", status_code=422)
+
+        raw_results = await self._provider.search(normalized_query, max_results=max_results)
+        return EvidenceSearchResult(
+            evidence=normalize_search_results(raw_results),
+            requirements=[
+                EvidenceRequirement(
+                    confidence=BoundedLevel.MEDIUM, min_sources=2, min_relevance=BoundedLevel.MEDIUM
+                ),
+                EvidenceRequirement(confidence=BoundedLevel.HIGH, min_sources=3, min_relevance=BoundedLevel.HIGH),
+            ],
+        )
+
+
+def normalize_search_results(results: list[dict[str, Any]]) -> list[Evidence]:
+    evidence: list[Evidence] = []
+    seen_sources: set[str] = set()
+
+    for result in results:
+        title = _clean_text(result.get("title"))
+        claim = _clean_text(result.get("content"))
+        if title is None or claim is None:
+            continue
+
+        url = _clean_text(result.get("url"))
+        dedupe_key = _source_key(title, url)
+        if dedupe_key in seen_sources:
+            continue
+        seen_sources.add(dedupe_key)
+
+        evidence.append(
+            Evidence(
+                claim=claim,
+                source_title=title,
+                source_url=url,
+                context=_clean_text(result.get("domain")) or _clean_text(result.get("author")),
+                source_published_at=_parse_datetime(result.get("published_date")),
+                relevance=_relevance(result.get("score")),
+            )
+        )
+
+    return evidence
+
+
+def _clean_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = " ".join(value.split())
+    return stripped or None
+
+
+def _source_key(title: str, url: str | None) -> str:
+    if url is not None:
+        return url.removesuffix("/").lower()
+    return title.lower()
+
+
+def _relevance(score: Any) -> BoundedLevel:
+    if not isinstance(score, int | float) or isinstance(score, bool) or score < 0 or score > 1:
+        raise ValueError("Search result relevance score must be a number from 0 to 1.")
+    if score >= 0.8:
+        return BoundedLevel.HIGH
+    if score >= 0.5:
+        return BoundedLevel.MEDIUM
+    return BoundedLevel.LOW
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/workflow-python/tests/test_evidence_research.py
+++ b/workflow-python/tests/test_evidence_research.py
@@ -1,0 +1,103 @@
+from typing import Any
+
+import httpx
+import pytest
+
+from app.contracts.workflow import BoundedLevel
+from app.tools.evidence_research import (
+    EvidenceResearchTool,
+    MockSearchProvider,
+    TavilySearchProvider,
+    normalize_search_results,
+)
+
+
+def _result(**overrides: Any) -> dict[str, Any]:
+    result = {
+        "title": "Official Jobs Report",
+        "url": "https://example.test/jobs",
+        "content": "The official report says payrolls increased by 180,000 in April.",
+        "score": 0.91,
+        "published_date": "2026-05-01T12:00:00Z",
+        "domain": "example.test",
+    }
+    result.update(overrides)
+    return result
+
+
+def test_normalizes_search_results_to_traceable_evidence() -> None:
+    evidence = normalize_search_results([_result(title="  Official Jobs Report  ", content=" Payrolls rose.  ")])
+
+    assert len(evidence) == 1
+    assert evidence[0].claim == "Payrolls rose."
+    assert evidence[0].source_title == "Official Jobs Report"
+    assert str(evidence[0].source_url) == "https://example.test/jobs"
+    assert evidence[0].context == "example.test"
+    assert evidence[0].source_published_at is not None
+    assert evidence[0].relevance == BoundedLevel.HIGH
+
+
+def test_deduplicates_obviously_repeated_sources() -> None:
+    evidence = normalize_search_results(
+        [
+            _result(title="First", url="https://example.test/jobs/", content="First claim."),
+            _result(title="Second", url="https://example.test/jobs", content="Second claim."),
+            _result(title="Official Jobs Report", url=None, content="Title duplicate."),
+            _result(title="Official Jobs Report", url=None, content="Title duplicate again."),
+        ]
+    )
+
+    assert [item.claim for item in evidence] == ["First claim.", "Title duplicate."]
+
+
+def test_missing_url_is_allowed() -> None:
+    evidence = normalize_search_results([_result(url=None)])
+
+    assert evidence[0].source_url is None
+
+
+def test_invalid_relevance_score_is_rejected() -> None:
+    with pytest.raises(ValueError, match="relevance score"):
+        normalize_search_results([_result(score=1.2)])
+
+
+@pytest.mark.asyncio
+async def test_mock_provider_supports_testable_research_path() -> None:
+    tool = EvidenceResearchTool(MockSearchProvider([_result(score=0.7), _result(title="Other", url=None, score=0.4)]))
+
+    result = await tool.gather("jobs report", max_results=2)
+
+    assert [item.relevance for item in result.evidence] == [BoundedLevel.MEDIUM, BoundedLevel.LOW]
+    requirements = {
+        (requirement.confidence, requirement.min_sources, requirement.min_relevance)
+        for requirement in result.requirements
+    }
+    assert requirements == {
+        (BoundedLevel.MEDIUM, 2, BoundedLevel.MEDIUM),
+        (BoundedLevel.HIGH, 3, BoundedLevel.HIGH),
+    }
+
+
+@pytest.mark.asyncio
+async def test_tavily_provider_posts_live_search_request_shape() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"results": [_result()]})
+
+    provider = TavilySearchProvider(
+        api_key="test-key",
+        api_url="https://tavily.test/search",
+        transport=httpx.MockTransport(handler),
+    )
+
+    results = await provider.search("jobs report", max_results=3)
+
+    assert results == [_result()]
+    assert requests[0].url == "https://tavily.test/search"
+    assert requests[0].headers["authorization"] == "Bearer test-key"
+    assert requests[0].read() == (
+        b'{"query":"jobs report","search_depth":"basic","topic":"news",'
+        b'"include_answer":false,"max_results":3}'
+    )


### PR DESCRIPTION
## Summary
- Add a testable evidence research tool with Tavily live search and mock search providers.
- Normalize evidence claims, source metadata, optional URLs, recency/context, relevance, and confidence requirements.
- Cover normalization, deduplication, missing URL handling, invalid relevance, mock mode, and Tavily request shape with tests.

## Tests
- uv run pytest
- uv run ruff check .
- uv run mypy .

Closes #7