### PR TITLE
Add settlement-risk audit workflow

### DIFF
--- a/workflow-python/app/orchestrator/service.py
+++ b/workflow-python/app/orchestrator/service.py
@@ -6,9 +6,7 @@ from pydantic import ValidationError
 from app.contracts.workflow import (
     AgentRole,
     AgentTraceEntry,
-    BoundedLevel,
     Evidence,
-    SettlementRisk,
     WorkflowRequest,
     WorkflowResponse,
 )
@@ -18,6 +16,7 @@ from app.fixtures.demo_response import build_demo_response
 from app.tools.evidence_research import EvidenceResearchTool, EvidenceSearchResult, TavilySearchProvider
 from app.tools.kalshi_market_data import KalshiPublicMarketDataTool, PublicMarketData
 from app.tools.probability_scoring import ProbabilityScoringResult, score_probability
+from app.tools.settlement_risk import audit_settlement_risk
 
 
 class MarketDataTool(Protocol):
@@ -64,7 +63,7 @@ class WorkflowService:
             market_data = await self._market_data_tool.fetch(request.market_input, now=datetime.now(UTC))
             trace.append(_trace(AgentRole.MARKET_DATA, "Captured public Kalshi market data and price context."))
 
-            settlement_risks = _settlement_risks(market_data)
+            settlement_risks = audit_settlement_risk(market_data)
             trace.append(_trace(AgentRole.SETTLEMENT_RULES, "Reviewed settlement source and wording ambiguity."))
 
             research = await self._research_tool.gather(_research_query(market_data), max_results=5)
@@ -108,22 +107,6 @@ def get_workflow_service() -> WorkflowService:
 def _trace(role: AgentRole, summary: str) -> AgentTraceEntry:
     display_names = dict(AGENT_SEQUENCE)
     return AgentTraceEntry(role=role, display_name=display_names[role], summary=summary, status="completed")
-
-
-def _settlement_risks(market_data: PublicMarketData) -> list[SettlementRisk]:
-    if market_data.market.settlement_source:
-        return [
-            SettlementRisk(
-                risk="Settlement depends on the exact official source and market rules wording.",
-                severity=BoundedLevel.MEDIUM,
-            )
-        ]
-    return [
-        SettlementRisk(
-            risk="Market response did not include an explicit settlement source.",
-            severity=BoundedLevel.HIGH,
-        )
-    ]
 
 
 def _research_query(market_data: PublicMarketData) -> str:

--- a/workflow-python/app/tools/settlement_risk.py
+++ b/workflow-python/app/tools/settlement_risk.py
@@ -1,0 +1,107 @@
+from datetime import UTC, datetime, timedelta
+
+from app.contracts.workflow import BoundedLevel, SettlementRisk
+from app.tools.kalshi_market_data import PublicMarketData
+
+AMBIGUOUS_TITLE_TERMS = (
+    "significant",
+    "major",
+    "substantial",
+    "any",
+    "first",
+    "happen",
+    "announce",
+    "confirm",
+    "reported",
+)
+CLOSE_TIME_TERMS = ("by ", "before", "after", "during", "through", "as of")
+SOURCE_GOTCHA_TERMS = (
+    "according to",
+    "as reported by",
+    "as determined by",
+    "official",
+    "preliminary",
+    "revised",
+    "rounded",
+    "seasonally adjusted",
+    "notwithstanding",
+)
+MISMATCH_TERMS = (
+    "only if",
+    "will not include",
+    "does not include",
+    "excluding",
+    "for purposes of",
+    "notwithstanding",
+    "regardless of",
+    "solely",
+)
+
+
+def audit_settlement_risk(market_data: PublicMarketData) -> list[SettlementRisk]:
+    risks: list[SettlementRisk] = []
+    title = market_data.market.title.lower()
+    subtitle = (market_data.market.subtitle or "").lower()
+    source = (market_data.market.settlement_source or "").lower()
+    contract_text = f"{title} {subtitle} {source}"
+
+    if any(term in title for term in AMBIGUOUS_TITLE_TERMS):
+        risks.append(
+            SettlementRisk(
+                risk="Market title uses wording that may need the full rules to interpret precisely.",
+                severity=BoundedLevel.MEDIUM,
+            )
+        )
+
+    if market_data.market.close_time is None:
+        risks.append(
+            SettlementRisk(
+                risk="Market metadata did not include a close time, so cutoff timing could affect interpretation.",
+                severity=BoundedLevel.MEDIUM,
+            )
+        )
+    else:
+        close_time = market_data.market.close_time
+        normalized_close_time = close_time if close_time.tzinfo else close_time.replace(tzinfo=UTC)
+        closes_soon = normalized_close_time <= datetime.now(UTC) + timedelta(days=1)
+        if any(term in contract_text for term in CLOSE_TIME_TERMS) or closes_soon:
+            risks.append(
+                SettlementRisk(
+                    risk=(
+                        "Close time may differ from the intuitive event window; check the exact cutoff before relying "
+                        "on late evidence."
+                    ),
+                    severity=BoundedLevel.MEDIUM,
+                )
+            )
+
+    if market_data.market.settlement_source is None:
+        risks.append(
+            SettlementRisk(
+                risk="Market response did not include an explicit settlement source.",
+                severity=BoundedLevel.HIGH,
+            )
+        )
+    elif any(term in source for term in SOURCE_GOTCHA_TERMS):
+        risks.append(
+            SettlementRisk(
+                risk="Settlement depends on the named source's exact publication, revision, or determination rules.",
+                severity=BoundedLevel.MEDIUM,
+            )
+        )
+
+    if any(term in source for term in MISMATCH_TERMS):
+        risks.append(
+            SettlementRisk(
+                risk="The intuitive user question may not match the market's narrower contract wording.",
+                severity=BoundedLevel.HIGH,
+            )
+        )
+
+    if risks:
+        return risks
+    return [
+        SettlementRisk(
+            risk="No obvious settlement wording, source, or cutoff gotchas detected.", severity=BoundedLevel.LOW
+        )
+    ]

--- a/workflow-python/tests/test_settlement_risk.py
+++ b/workflow-python/tests/test_settlement_risk.py
@@ -1,0 +1,90 @@
+from datetime import UTC, datetime, timedelta
+
+from app.contracts.workflow import BoundedLevel, SettlementRisk
+from app.tools.kalshi_market_data import MarketMetadata, PriceContext, PublicMarketData
+from app.tools.settlement_risk import audit_settlement_risk
+
+
+def test_audit_flags_ambiguous_wording() -> None:
+    risks = audit_settlement_risk(
+        _market_data(
+            title="Will a major AI lab announce any new model?",
+            settlement_source="Company press releases will be used for resolution.",
+        )
+    )
+
+    assert any("title uses wording" in risk.risk and risk.severity == BoundedLevel.MEDIUM for risk in risks)
+
+
+def test_audit_flags_close_time_risk() -> None:
+    risks = audit_settlement_risk(
+        _market_data(
+            title="Will the bill pass before Friday?",
+            close_time=datetime.now(UTC) + timedelta(hours=12),
+            settlement_source="Official congressional record.",
+        )
+    )
+
+    assert any("Close time" in risk.risk and risk.severity == BoundedLevel.MEDIUM for risk in risks)
+
+
+def test_audit_flags_resolution_source_risk() -> None:
+    risks = audit_settlement_risk(
+        _market_data(
+            title="Will CPI be above 3%?",
+            settlement_source=(
+                "Resolved according to the official seasonally adjusted BLS release, including revisions."
+            ),
+        )
+    )
+
+    assert any("named source" in risk.risk and risk.severity == BoundedLevel.MEDIUM for risk in risks)
+
+
+def test_audit_flags_intuitive_question_mismatch() -> None:
+    risks = audit_settlement_risk(
+        _market_data(
+            title="Will the team win the championship?",
+            settlement_source="Resolves yes only if the league names the team champion, excluding vacated titles.",
+        )
+    )
+
+    assert any("intuitive user question" in risk.risk and risk.severity == BoundedLevel.HIGH for risk in risks)
+
+
+def test_audit_returns_low_risk_note_when_no_gotchas_detected() -> None:
+    risks = audit_settlement_risk(
+        _market_data(title="Will Candidate A win the election?", settlement_source="Final certified election result.")
+    )
+
+    assert risks == [
+        SettlementRisk(
+            risk="No obvious settlement wording, source, or cutoff gotchas detected.", severity=BoundedLevel.LOW
+        )
+    ]
+
+
+def _market_data(
+    *,
+    title: str,
+    settlement_source: str | None,
+    close_time: datetime | None = None,
+) -> PublicMarketData:
+    if close_time is None:
+        close_time = datetime(2100, 12, 31, tzinfo=UTC)
+    return PublicMarketData(
+        market=MarketMetadata(
+            ticker="KXTEST",
+            title=title,
+            subtitle="",
+            url="https://kalshi.com/markets/KXTEST",
+            status="open",
+            closeTime=close_time,
+            settlementSource=settlement_source,
+        ),
+        impliedProbability=0.5,
+        prices=PriceContext(yesBid=0.48, yesAsk=0.52, lastPrice=0.5, spread=0.04),
+        volume=1000,
+        openInterest=500,
+        warnings=[],
+    )


### PR DESCRIPTION
## Summary
- Adds a first-class settlement-risk audit module for ambiguous wording, close-time gotchas, source-specific resolution risk, and intuitive-question mismatch.
- Wires the audit into the workflow settlement rules step without changing the typed frontend response contract.
- Adds focused Python tests for the issue 6 acceptance cases, including low-risk output.

## Tests
- `.venv/bin/pytest`
- `.venv/bin/ruff check .`

Closes #6