### PR TITLE
Add cursor pointer and enlarge header title

### DIFF
--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -11,7 +11,7 @@ export function SiteHeader() {
         <button
           type="button"
           onClick={goHome}
-          className="text-foreground hover:text-foreground/70 focus-visible:ring-ring rounded-sm text-sm font-semibold tracking-tight transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+          className="text-foreground hover:text-foreground/70 focus-visible:ring-ring cursor-pointer rounded-sm text-lg font-semibold tracking-tight transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 sm:text-xl"
         >
           Kalshi AI Research
         </button>


### PR DESCRIPTION
## Summary
- Add `cursor-pointer` to the clickable site header so the pointer shows on hover (Tailwind preflight resets the default button cursor).
- Bump the "Kalshi AI Research" title from `text-sm` to `text-lg` (`sm:text-xl` on larger screens) for better visibility.

## Test plan
- [ ] Hover the header title — cursor turns into a pointer.
- [ ] Click the header title — navigates to the home view.
- [ ] Title looks appropriately sized on mobile and desktop widths.