### PR TITLE
Apply Kalshi brand color to primary actions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -51,19 +51,19 @@
   --card-foreground: oklch(0.18 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.18 0 0);
-  --primary: oklch(0.18 0 0);
+  --primary: oklch(0.62 0.13 170);
   --primary-foreground: oklch(1 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.18 0 0);
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.5 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.18 0 0);
+  --accent: oklch(0.96 0.04 170);
+  --accent-foreground: oklch(0.35 0.09 170);
   --destructive: oklch(0.6 0.2 25);
   --border: oklch(0.92 0 0);
   --input: oklch(0.92 0 0);
-  --ring: oklch(0.18 0 0);
-  --chart-1: oklch(0.18 0 0);
+  --ring: oklch(0.62 0.13 170);
+  --chart-1: oklch(0.62 0.13 170);
   --chart-2: oklch(0.5 0 0);
   --chart-3: oklch(0.7 0 0);
   --chart-4: oklch(0.85 0 0);
@@ -71,12 +71,14 @@
   --radius: 0.375rem;
   --sidebar: oklch(1 0 0);
   --sidebar-foreground: oklch(0.18 0 0);
-  --sidebar-primary: oklch(0.18 0 0);
+  --sidebar-primary: oklch(0.62 0.13 170);
   --sidebar-primary-foreground: oklch(1 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.18 0 0);
+  --sidebar-accent: oklch(0.96 0.04 170);
+  --sidebar-accent-foreground: oklch(0.35 0.09 170);
   --sidebar-border: oklch(0.92 0 0);
-  --sidebar-ring: oklch(0.18 0 0);
+  --sidebar-ring: oklch(0.62 0.13 170);
+  --brand: oklch(0.62 0.13 170);
+  --brand-soft: oklch(0.96 0.04 170);
 }
 
 @layer base {

--- a/components/idle-view.tsx
+++ b/components/idle-view.tsx
@@ -14,14 +14,14 @@ export function IdleView({ onSubmit }: Props) {
 
   return (
     <section aria-labelledby="masthead-heading" className="mx-auto flex max-w-2xl flex-col gap-10">
-      <div className="flex flex-col gap-3 text-center">
+      <div className="flex flex-col items-center gap-4 text-center">
         <h1
           id="masthead-heading"
-          className="text-foreground text-3xl font-semibold tracking-tight sm:text-4xl"
+          className="text-foreground text-3xl font-semibold tracking-tight sm:text-5xl"
         >
-          Research a Kalshi market in seconds.
+          Research a Kalshi market in <span className="text-primary">seconds</span>.
         </h1>
-        <p className="text-muted-foreground text-base leading-relaxed">
+        <p className="text-muted-foreground max-w-xl text-base leading-relaxed">
           Paste a market URL or ticker. Six agents read the rules, gather evidence, and return a research
           memo.
         </p>


### PR DESCRIPTION
## Summary
- Switch primary, ring, and accent CSS tokens to a Kalshi mint/teal so buttons and focus states carry brand color.
- Tighten the idle hero: larger heading, with the word "seconds" highlighted in brand color.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test`
- [ ] Visual check at `/` — CTA, focus ring, and hero highlight read as Kalshi mint