### PR TITLE
Add brand logo to left of header

### DIFF
--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -11,8 +11,24 @@ export function SiteHeader() {
         <button
           type="button"
           onClick={goHome}
-          className="text-foreground hover:text-foreground/70 focus-visible:ring-ring cursor-pointer rounded-sm text-lg font-semibold tracking-tight transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 sm:text-xl"
+          className="text-foreground hover:text-foreground/70 focus-visible:ring-ring flex cursor-pointer items-center gap-2 rounded-sm text-lg font-semibold tracking-tight transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 sm:text-xl"
         >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 32 32"
+            fill="none"
+            aria-hidden="true"
+            className="h-7 w-7 shrink-0 sm:h-8 sm:w-8"
+          >
+            <rect width="32" height="32" rx="6" fill="currentColor" />
+            <path
+              d="M11 8 V24 M11 16 L21 8 M11 16 L21 24"
+              stroke="var(--background, #ffffff)"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
           Kalshi AI Research
         </button>
       </div>


### PR DESCRIPTION
## Summary
- Adds an inline SVG logo (the existing K-arrow mark from `app/icon.svg`) to the left of the "Kalshi AI Research" title in `SiteHeader`
- Logo sits inside the existing home button so the whole brand block stays clickable

## Test plan
- [ ] `npm run dev` and confirm the logo renders to the left of the title
- [ ] Click the logo — should still fire the `kalshi:home` event
- [ ] Verify it scales correctly at sm and below breakpoints