### PR TITLE
Integrate live workflow request flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,2 @@
-# Google Gemini API key.
-GEMINI_API_KEY=""
-
-# Additional web-search API for agents
-TAVILY_API_KEY=""
+# Browser-safe workflow endpoint. Secret-bearing keys belong in workflow-python/.env.
+NEXT_PUBLIC_WORKFLOW_ENDPOINT="http://127.0.0.1:8000/analyze"

--- a/README.md
+++ b/README.md
@@ -112,9 +112,10 @@ curl -X POST http://127.0.0.1:8000/analyze \
 Root `.env.example`:
 
 ```bash
-GEMINI_API_KEY=""
-TAVILY_API_KEY=""
+NEXT_PUBLIC_WORKFLOW_ENDPOINT="http://127.0.0.1:8000/analyze"
 ```
+
+The frontend only needs `NEXT_PUBLIC_WORKFLOW_ENDPOINT`. Do not put Gemini, Tavily, Kalshi private, or other secret-bearing API keys in root browser-facing environment variables.
 
 Workflow service settings use the `WORKFLOW_` prefix from `workflow-python/app/core/config.py`:
 
@@ -197,4 +198,4 @@ The TypeScript contract lives in `contracts/workflow/workflow-contract.ts`. The 
 
 ## Current Status
 
-This repository is an MVP prototype. The frontend currently renders idle, loading, error, and validated-success placeholder states. The Python workflow API exposes `GET /health` and `POST /analyze`, with deterministic demo mode available immediately and live-market seams for Kalshi public data and Tavily evidence search.
+This repository is an MVP prototype. The frontend renders idle, loading, explicit error, and validated research-memo success states. The Python workflow API exposes `GET /health` and `POST /analyze`, with deterministic demo mode available immediately and live-market seams for Kalshi public data and Tavily evidence search.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Workflow service settings use the `WORKFLOW_` prefix from `workflow-python/app/c
 | `WORKFLOW_GEMINI_BASE_URL`    | Overrides the Gemini API base URL, including OpenRouter-compatible endpoints. |
 | `WORKFLOW_CORS_ALLOW_ORIGINS` | Overrides local frontend origins allowed by CORS. |
 
+For OpenRouter, use `WORKFLOW_GEMINI_BASE_URL="https://openrouter.ai/api/v1"` and an OpenRouter model id such as `WORKFLOW_GEMINI_MODEL="google/gemini-2.5-flash"`. OpenRouter keys do not work against Google's `generativelanguage.googleapis.com` endpoint.
+
 Local CORS allows `http://localhost:3000` and `http://127.0.0.1:3000` by default.
 
 ## Development Commands

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Workflow service settings use the `WORKFLOW_` prefix from `workflow-python/app/c
 | Variable                      | Purpose                                           |
 | ----------------------------- | ------------------------------------------------- |
 | `WORKFLOW_TAVILY_API_KEY`     | Enables live Tavily-backed evidence search.       |
+| `WORKFLOW_GEMINI_API_KEY`     | Enables live Gemini-backed probability analysis.  |
+| `WORKFLOW_GEMINI_MODEL`       | Overrides the Gemini model, default `gemini-2.5-flash`. |
+| `WORKFLOW_GEMINI_BASE_URL`    | Overrides the Gemini API base URL, including OpenRouter-compatible endpoints. |
 | `WORKFLOW_CORS_ALLOW_ORIGINS` | Overrides local frontend origins allowed by CORS. |
 
 Local CORS allows `http://localhost:3000` and `http://127.0.0.1:3000` by default.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -48,7 +48,7 @@ export default function Page() {
   }, [state.kind]);
 
   const view = renderView(state, {
-    onSubmit: submit,
+    onSubmit: (marketInput) => submit(marketInput, { demoMode: showDemoBar }),
     onReset: reset,
     onLoadDemo: () => setDemoState({ kind: "success", response: demoWorkflowResponse }),
   });

--- a/contracts/workflow/fixtures/demo-workflow-response.ts
+++ b/contracts/workflow/fixtures/demo-workflow-response.ts
@@ -119,5 +119,5 @@ export const demoWorkflowResponse: WorkflowResponse = {
     rawJsonLabel: "Validated workflow response JSON",
   },
   disclaimer:
-    "This is research-only analysis, not financial advice or a recommendation to buy, sell, or place any trade.",
+    "This is research-only analysis, not financial advice or trading advice, and not a recommendation or order instruction.",
 };

--- a/contracts/workflow/workflow-contract.ts
+++ b/contracts/workflow/workflow-contract.ts
@@ -12,6 +12,9 @@ export const agentRoleSchema = z.enum([
   "memo_editor",
 ]);
 
+const forbiddenRecommendationPattern =
+  /\b(?:you should|we recommend)\s+(?:buy|sell|place|enter|exit)\b|\b(?:recommendation|action|trade):\s*(?:buy|sell|place|enter|exit)\b|\b(?:buy|sell)\s+(?:now|this market|the contract)\b/i;
+
 export const workflowRequestSchema = z.object({
   marketInput: z.string().trim().min(1),
   requestedAt: z.string().datetime().optional(),
@@ -120,12 +123,38 @@ export const workflowResponseSchema = z
       }
     }
 
-    if (!/research|advice|trade/i.test(response.disclaimer)) {
+    const disclaimer = response.disclaimer.toLowerCase();
+    const hasResearchBoundary = disclaimer.includes("research") || disclaimer.includes("informational");
+    const rejectsAdvice = ["not financial advice", "not trading advice", "not advice"].some((phrase) =>
+      disclaimer.includes(phrase),
+    );
+    const rejectsTrade = ["not a recommendation", "not trade", "place any trade"].some((phrase) =>
+      disclaimer.includes(phrase),
+    );
+
+    if (!(hasResearchBoundary && rejectsAdvice && rejectsTrade)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["disclaimer"],
         message: "Disclaimer must clearly separate research from trading advice.",
       });
+    }
+
+    const authoredOutputs: Array<{ path: Array<string | number>; text: string }> = [
+      { path: ["agentEstimate", "thesis"], text: response.agentEstimate.thesis },
+      { path: ["finalMemoMarkdown"], text: response.finalMemoMarkdown },
+      ...response.counterarguments.map((text, index) => ({ path: ["counterarguments", index], text })),
+      ...response.whatWouldChange.map((text, index) => ({ path: ["whatWouldChange", index], text })),
+    ];
+
+    for (const output of authoredOutputs) {
+      if (forbiddenRecommendationPattern.test(output.text)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: output.path,
+          message: "Workflow output must not include direct buy/sell/place-trade recommendation phrasing.",
+        });
+      }
     }
   });
 

--- a/features/research-memo/market-input-normalization.ts
+++ b/features/research-memo/market-input-normalization.ts
@@ -1,0 +1,40 @@
+export interface NormalizedMarketInput {
+  marketInput: string;
+  source: "ticker" | "url";
+}
+
+const TICKER_PATTERN = /^KX[A-Z0-9-]{3,}$/;
+const KALSHI_HOST_PATTERN = /(^|\.)kalshi\.com$/i;
+
+export function normalizeMarketInput(input: string): NormalizedMarketInput | null {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) return null;
+
+  const fromUrl = normalizeKalshiUrl(trimmed);
+  if (fromUrl !== null) return { marketInput: fromUrl, source: "url" };
+
+  const ticker = trimmed.toUpperCase();
+  if (TICKER_PATTERN.test(ticker)) return { marketInput: ticker, source: "ticker" };
+
+  return null;
+}
+
+function normalizeKalshiUrl(input: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return null;
+  }
+
+  if (!KALSHI_HOST_PATTERN.test(url.hostname)) return null;
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  const marketIndex = segments.findIndex((segment) => segment.toLowerCase() === "markets");
+  if (marketIndex === -1) return null;
+
+  const ticker = segments
+    .slice(marketIndex + 1)
+    .find((segment) => TICKER_PATTERN.test(segment.toUpperCase()));
+  return ticker?.toUpperCase() ?? null;
+}

--- a/features/research-memo/market-input-normalization.ts
+++ b/features/research-memo/market-input-normalization.ts
@@ -35,6 +35,7 @@ function normalizeKalshiUrl(input: string): string | null {
 
   const ticker = segments
     .slice(marketIndex + 1)
-    .find((segment) => TICKER_PATTERN.test(segment.toUpperCase()));
+    .filter((segment) => TICKER_PATTERN.test(segment.toUpperCase()))
+    .at(-1);
   return ticker?.toUpperCase() ?? null;
 }

--- a/features/research-memo/state.ts
+++ b/features/research-memo/state.ts
@@ -1,6 +1,15 @@
 import type { WorkflowResponse } from "@/contracts/workflow/workflow-contract";
 
-export type ErrorReason = "invalid_input" | "workflow_unavailable" | "malformed_response" | "timeout";
+import type { NormalizedMarketInput } from "./market-input-normalization";
+
+export type ErrorReason =
+  | "invalid_input"
+  | "workflow_unavailable"
+  | "malformed_response"
+  | "market_data_unavailable"
+  | "search_failure"
+  | "model_failure"
+  | "timeout";
 
 export const errorReasonCopy: Record<ErrorReason, { title: string; detail: string }> = {
   invalid_input: {
@@ -15,6 +24,18 @@ export const errorReasonCopy: Record<ErrorReason, { title: string; detail: strin
     title: "Workflow response failed validation",
     detail: "The response did not match the contract. Retry or load the demo fixture.",
   },
+  market_data_unavailable: {
+    title: "Market data is unavailable",
+    detail: "The workflow could not retrieve public Kalshi market data for this input.",
+  },
+  search_failure: {
+    title: "Evidence search failed",
+    detail: "The research agent could not gather external evidence for this run.",
+  },
+  model_failure: {
+    title: "Model reasoning failed",
+    detail: "The model-backed agent step failed before producing a validated memo.",
+  },
   timeout: {
     title: "Workflow timed out",
     detail: "The agents did not complete in time. Retry or load the demo fixture.",
@@ -28,7 +49,7 @@ export type State =
   | { kind: "error"; reason: ErrorReason; marketInput?: string };
 
 export type Action =
-  | { type: "SUBMIT"; marketInput: string }
+  | { type: "SUBMIT"; input: NormalizedMarketInput }
   | { type: "SUCCEED"; response: WorkflowResponse }
   | { type: "FAIL"; reason: ErrorReason }
   | { type: "RESET" }
@@ -39,11 +60,7 @@ export const initialState: State = { kind: "idle" };
 export function reducer(state: State, action: Action): State {
   switch (action.type) {
     case "SUBMIT": {
-      const trimmed = action.marketInput.trim();
-      if (trimmed.length === 0) {
-        return { kind: "error", reason: "invalid_input" };
-      }
-      return { kind: "submitting", marketInput: trimmed };
+      return { kind: "submitting", marketInput: action.input.marketInput };
     }
     case "SUCCEED": {
       if (state.kind !== "submitting") return state;

--- a/features/research-memo/use-research-memo.ts
+++ b/features/research-memo/use-research-memo.ts
@@ -1,14 +1,16 @@
 "use client";
 
-import { useCallback, useReducer } from "react";
+import { useCallback, useReducer, useRef } from "react";
 
 import type { WorkflowResponse } from "@/contracts/workflow/workflow-contract";
 
+import { normalizeMarketInput } from "./market-input-normalization";
 import { type Action, type ErrorReason, type State, initialState, reducer } from "./state";
+import { runWorkflow } from "./workflow-client";
 
 export interface ResearchMemoController {
   state: State;
-  submit: (marketInput: string) => void;
+  submit: (marketInput: string, options?: { demoMode?: boolean }) => void;
   succeed: (response: WorkflowResponse) => void;
   fail: (reason: ErrorReason) => void;
   reset: () => void;
@@ -17,9 +19,35 @@ export interface ResearchMemoController {
 
 export function useResearchMemo(initial: State = initialState): ResearchMemoController {
   const [state, dispatch] = useReducer(reducer, initial);
+  const requestIdRef = useRef(0);
 
-  const submit = useCallback((marketInput: string) => {
-    dispatch({ type: "SUBMIT", marketInput });
+  const submit = useCallback((marketInput: string, options?: { demoMode?: boolean }) => {
+    const normalized = normalizeMarketInput(marketInput);
+    if (normalized === null) {
+      dispatch({ type: "FAIL", reason: "invalid_input" });
+      return;
+    }
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    dispatch({ type: "SUBMIT", input: normalized });
+
+    void runWorkflow({
+      marketInput: normalized.marketInput,
+      ...(options?.demoMode === undefined ? {} : { demoMode: options.demoMode }),
+    })
+      .then((result) => {
+        if (requestId !== requestIdRef.current) return;
+        if (result.ok) {
+          dispatch({ type: "SUCCEED", response: result.response });
+        } else {
+          dispatch({ type: "FAIL", reason: result.failure.reason });
+        }
+      })
+      .catch(() => {
+        if (requestId !== requestIdRef.current) return;
+        dispatch({ type: "FAIL", reason: "workflow_unavailable" });
+      });
   }, []);
 
   const succeed = useCallback((response: WorkflowResponse) => {
@@ -31,6 +59,7 @@ export function useResearchMemo(initial: State = initialState): ResearchMemoCont
   }, []);
 
   const reset = useCallback(() => {
+    requestIdRef.current += 1;
     dispatch({ type: "RESET" });
   }, []);
 

--- a/features/research-memo/workflow-client.ts
+++ b/features/research-memo/workflow-client.ts
@@ -1,0 +1,98 @@
+import { demoWorkflowResponse } from "@/contracts/workflow/fixtures/demo-workflow-response";
+import {
+  validateWorkflowResponse,
+  workflowRequestSchema,
+  type WorkflowResponse,
+} from "@/contracts/workflow/workflow-contract";
+
+import type { ErrorReason } from "./state";
+
+export interface RunWorkflowOptions {
+  marketInput: string;
+  demoMode?: boolean;
+  timeoutMs?: number;
+}
+
+export interface WorkflowFailure {
+  reason: ErrorReason;
+}
+
+export type WorkflowResult =
+  | { ok: true; response: WorkflowResponse }
+  | { ok: false; failure: WorkflowFailure };
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+export async function runWorkflow({
+  marketInput,
+  demoMode = false,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}: RunWorkflowOptions): Promise<WorkflowResult> {
+  const request = workflowRequestSchema.safeParse({
+    marketInput,
+    requestedAt: new Date().toISOString(),
+    demoMode,
+  });
+
+  if (!request.success) return { ok: false, failure: { reason: "invalid_input" } };
+  if (demoMode) return { ok: true, response: demoWorkflowResponse };
+
+  const endpoint = process.env.NEXT_PUBLIC_WORKFLOW_ENDPOINT;
+  if (endpoint === undefined || endpoint.trim().length === 0) {
+    return { ok: false, failure: { reason: "workflow_unavailable" } };
+  }
+
+  const controller = new AbortController();
+  const timeout = globalThis.setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(request.data),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) return { ok: false, failure: { reason: await mapHttpFailure(response) } };
+
+    const payload: unknown = await response.json();
+    const parsed = validateWorkflowResponse(payload);
+    if (!parsed.success) return { ok: false, failure: { reason: "malformed_response" } };
+
+    return { ok: true, response: parsed.data };
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      return { ok: false, failure: { reason: "timeout" } };
+    }
+    return { ok: false, failure: { reason: "workflow_unavailable" } };
+  } finally {
+    globalThis.clearTimeout(timeout);
+  }
+}
+
+async function mapHttpFailure(response: Response): Promise<ErrorReason> {
+  const code = await readErrorCode(response);
+  if (code === "invalid_input") return "invalid_input";
+  if (code === "market_data_unavailable") return "market_data_unavailable";
+  if (code === "search_failure") return "search_failure";
+  if (code === "model_failure") return "model_failure";
+  if (code === "malformed_workflow_output") return "malformed_response";
+
+  if (response.status === 400 || response.status === 422) return "invalid_input";
+  if (response.status === 502) return "malformed_response";
+  if (response.status === 408 || response.status === 504) return "timeout";
+  return "workflow_unavailable";
+}
+
+async function readErrorCode(response: Response): Promise<string | null> {
+  try {
+    const payload: unknown = await response.json();
+    if (payload !== null && typeof payload === "object" && "code" in payload) {
+      const code = payload.code;
+      return typeof code === "string" ? code : null;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}

--- a/features/research-memo/workflow-client.ts
+++ b/features/research-memo/workflow-client.ts
@@ -55,8 +55,10 @@ export async function runWorkflow({
 
     if (!response.ok) return { ok: false, failure: { reason: await mapHttpFailure(response) } };
 
-    const payload: unknown = await response.json();
-    const parsed = validateWorkflowResponse(payload);
+    const payload = await readSuccessPayload(response);
+    if (!payload.ok) return { ok: false, failure: { reason: "malformed_response" } };
+
+    const parsed = validateWorkflowResponse(payload.value);
     if (!parsed.success) return { ok: false, failure: { reason: "malformed_response" } };
 
     return { ok: true, response: parsed.data };
@@ -67,6 +69,14 @@ export async function runWorkflow({
     return { ok: false, failure: { reason: "workflow_unavailable" } };
   } finally {
     globalThis.clearTimeout(timeout);
+  }
+}
+
+async function readSuccessPayload(response: Response): Promise<{ ok: true; value: unknown } | { ok: false }> {
+  try {
+    return { ok: true, value: await response.json() };
+  } catch {
+    return { ok: false };
   }
 }
 

--- a/tests/contracts/workflow-contract.test.ts
+++ b/tests/contracts/workflow-contract.test.ts
@@ -101,6 +101,36 @@ describe("workflow response contract", () => {
     expect(result.error?.issues.some((issue) => issue.path.join(".") === "disclaimer")).toBe(true);
   });
 
+  it("rejects weak research-only disclaimers that do not reject advice and recommendations", () => {
+    const result = validateWorkflowResponse({
+      ...demoWorkflowResponse,
+      disclaimer: "Research output only.",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.some((issue) => issue.path.join(".") === "disclaimer")).toBe(true);
+  });
+
+  it("rejects direct recommendation phrasing in workflow-authored output", () => {
+    const result = validateWorkflowResponse({
+      ...demoWorkflowResponse,
+      finalMemoMarkdown: "## Research Memo\n\nYou should buy this market now.",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.some((issue) => issue.path.join(".") === "finalMemoMarkdown")).toBe(true);
+  });
+
+  it("rejects direct recommendation phrasing with recommend wording", () => {
+    const result = validateWorkflowResponse({
+      ...demoWorkflowResponse,
+      finalMemoMarkdown: "## Research Memo\n\nWe recommend sell based on this evidence.",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.some((issue) => issue.path.join(".") === "finalMemoMarkdown")).toBe(true);
+  });
+
   it("requires all six named agent trace roles", () => {
     const result = validateWorkflowResponse({
       ...demoWorkflowResponse,

--- a/tests/features/research-memo/market-input-normalization.test.ts
+++ b/tests/features/research-memo/market-input-normalization.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeMarketInput } from "@/features/research-memo/market-input-normalization";
+
+describe("market input normalization", () => {
+  it("accepts and normalizes Kalshi tickers", () => {
+    expect(normalizeMarketInput("  kxexample-26may03-demo  ")).toEqual({
+      marketInput: "KXEXAMPLE-26MAY03-DEMO",
+      source: "ticker",
+    });
+  });
+
+  it("extracts tickers from Kalshi market URLs and ignores tracking parameters", () => {
+    expect(
+      normalizeMarketInput("https://kalshi.com/markets/KXEXAMPLE-26MAY03-DEMO?utm_source=test&ref=demo"),
+    ).toEqual({ marketInput: "KXEXAMPLE-26MAY03-DEMO", source: "url" });
+  });
+
+  it("rejects empty and non-Kalshi inputs", () => {
+    expect(normalizeMarketInput("   ")).toBeNull();
+    expect(normalizeMarketInput("https://example.com/markets/KXEXAMPLE-26MAY03-DEMO")).toBeNull();
+    expect(normalizeMarketInput("not a ticker")).toBeNull();
+  });
+});

--- a/tests/features/research-memo/market-input-normalization.test.ts
+++ b/tests/features/research-memo/market-input-normalization.test.ts
@@ -16,6 +16,13 @@ describe("market input normalization", () => {
     ).toEqual({ marketInput: "KXEXAMPLE-26MAY03-DEMO", source: "url" });
   });
 
+  it("prefers the concrete market ticker over the series slug in Kalshi URLs", () => {
+    expect(normalizeMarketInput("https://kalshi.com/markets/kxmuskoai/elon-win-vs-open-ai/kxmuskoai-26")).toEqual({
+      marketInput: "KXMUSKOAI-26",
+      source: "url",
+    });
+  });
+
   it("rejects empty and non-Kalshi inputs", () => {
     expect(normalizeMarketInput("   ")).toBeNull();
     expect(normalizeMarketInput("https://example.com/markets/KXEXAMPLE-26MAY03-DEMO")).toBeNull();

--- a/tests/features/research-memo/state.test.ts
+++ b/tests/features/research-memo/state.test.ts
@@ -9,13 +9,11 @@ describe("research-memo state machine", () => {
   });
 
   it("transitions idle -> submitting on a non-empty input", () => {
-    const next = reducer({ kind: "idle" }, { type: "SUBMIT", marketInput: "  KX-DEMO  " });
+    const next = reducer(
+      { kind: "idle" },
+      { type: "SUBMIT", input: { marketInput: "KX-DEMO", source: "ticker" } },
+    );
     expect(next).toEqual({ kind: "submitting", marketInput: "KX-DEMO" });
-  });
-
-  it("rejects empty market input as an invalid_input error", () => {
-    const next = reducer({ kind: "idle" }, { type: "SUBMIT", marketInput: "   " });
-    expect(next).toEqual({ kind: "error", reason: "invalid_input" });
   });
 
   it("transitions submitting -> success only when a response arrives", () => {

--- a/tests/features/research-memo/workflow-client.test.ts
+++ b/tests/features/research-memo/workflow-client.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { demoWorkflowResponse } from "@/contracts/workflow/fixtures/demo-workflow-response";
+import { runWorkflow } from "@/features/research-memo/workflow-client";
+
+const originalEndpoint = process.env.NEXT_PUBLIC_WORKFLOW_ENDPOINT;
+
+describe("workflow client", () => {
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_WORKFLOW_ENDPOINT = originalEndpoint;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("calls the configured workflow endpoint and validates a successful response", async () => {
+    process.env.NEXT_PUBLIC_WORKFLOW_ENDPOINT = "https://workflow.example.test/analyze";
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => demoWorkflowResponse });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runWorkflow({ marketInput: "KXEXAMPLE-26MAY03-DEMO" });
+
+    expect(result).toEqual({ ok: true, response: demoWorkflowResponse });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://workflow.example.test/analyze",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("surfaces malformed workflow responses before rendering", async () => {
+    process.env.NEXT_PUBLIC_WORKFLOW_ENDPOINT = "https://workflow.example.test/analyze";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ schemaVersion: "1.0" }) }),
+    );
+
+    await expect(runWorkflow({ marketInput: "KXEXAMPLE-26MAY03-DEMO" })).resolves.toEqual({
+      ok: false,
+      failure: { reason: "malformed_response" },
+    });
+  });
+
+  it("keeps demo fixture fallback explicit", async () => {
+    process.env.NEXT_PUBLIC_WORKFLOW_ENDPOINT = undefined;
+
+    await expect(runWorkflow({ marketInput: "KXEXAMPLE-26MAY03-DEMO", demoMode: true })).resolves.toEqual({
+      ok: true,
+      response: demoWorkflowResponse,
+    });
+  });
+});

--- a/tests/features/research-memo/workflow-client.test.ts
+++ b/tests/features/research-memo/workflow-client.test.ts
@@ -39,6 +39,19 @@ describe("workflow client", () => {
     });
   });
 
+  it("maps unparsable successful responses to malformed workflow responses", async () => {
+    process.env.NEXT_PUBLIC_WORKFLOW_ENDPOINT = "https://workflow.example.test/analyze";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => Promise.reject(new SyntaxError("bad json")) }),
+    );
+
+    await expect(runWorkflow({ marketInput: "KXEXAMPLE-26MAY03-DEMO" })).resolves.toEqual({
+      ok: false,
+      failure: { reason: "malformed_response" },
+    });
+  });
+
   it("keeps demo fixture fallback explicit", async () => {
     process.env.NEXT_PUBLIC_WORKFLOW_ENDPOINT = undefined;
 

--- a/workflow-python/.env.example
+++ b/workflow-python/.env.example
@@ -2,3 +2,8 @@ WORKFLOW_TAVILY_API_KEY=""
 WORKFLOW_GEMINI_API_KEY=""
 WORKFLOW_GEMINI_MODEL="gemini-2.5-flash"
 WORKFLOW_GEMINI_BASE_URL="https://generativelanguage.googleapis.com/v1beta"
+
+# OpenRouter example:
+# WORKFLOW_GEMINI_API_KEY="sk-or-..."
+# WORKFLOW_GEMINI_MODEL="google/gemini-2.5-flash"
+# WORKFLOW_GEMINI_BASE_URL="https://openrouter.ai/api/v1"

--- a/workflow-python/.env.example
+++ b/workflow-python/.env.example
@@ -1,0 +1,4 @@
+WORKFLOW_TAVILY_API_KEY=""
+WORKFLOW_GEMINI_API_KEY=""
+WORKFLOW_GEMINI_MODEL="gemini-2.5-flash"
+WORKFLOW_GEMINI_BASE_URL="https://generativelanguage.googleapis.com/v1beta"

--- a/workflow-python/app/contracts/workflow.py
+++ b/workflow-python/app/contracts/workflow.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from enum import StrEnum
 from typing import Annotated, Literal
@@ -6,6 +7,12 @@ from pydantic import AnyUrl, BaseModel, ConfigDict, Field, StringConstraints, fi
 
 NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 Probability = Annotated[float, Field(ge=0, le=1)]
+FORBIDDEN_RECOMMENDATION_PATTERN = re.compile(
+    r"\b(?:you should|we recommend)\s+(?:buy|sell|place|enter|exit)\b"
+    r"|\b(?:recommendation|action|trade):\s*(?:buy|sell|place|enter|exit)\b"
+    r"|\b(?:buy|sell)\s+(?:now|this market|the contract)\b",
+    re.IGNORECASE,
+)
 
 
 class BoundedLevel(StrEnum):
@@ -144,6 +151,15 @@ class WorkflowResponse(BaseModel):
         if missing_roles:
             missing = ", ".join(sorted(role.value for role in missing_roles))
             raise ValueError(f"Agent trace must include {missing}.")
+
+        authored_outputs = [
+            self.agent_estimate.thesis,
+            self.final_memo_markdown,
+            *self.counterarguments,
+            *self.what_would_change,
+        ]
+        if any(FORBIDDEN_RECOMMENDATION_PATTERN.search(output) for output in authored_outputs):
+            raise ValueError("Workflow output must not include direct recommendation phrasing.")
 
         return self
 

--- a/workflow-python/app/core/config.py
+++ b/workflow-python/app/core/config.py
@@ -8,6 +8,9 @@ class Settings(BaseSettings):
     app_name: str = "Kalshi Research Workflow API"
     cors_allow_origins: list[str] = Field(default_factory=lambda: ["http://localhost:3000", "http://127.0.0.1:3000"])
     tavily_api_key: str | None = None
+    gemini_api_key: str | None = None
+    gemini_model: str = "gemini-2.5-flash"
+    gemini_base_url: str = "https://generativelanguage.googleapis.com/v1beta"
 
     model_config = SettingsConfigDict(env_prefix="WORKFLOW_", env_file=".env", extra="ignore")
 

--- a/workflow-python/app/core/config.py
+++ b/workflow-python/app/core/config.py
@@ -1,18 +1,42 @@
 from functools import lru_cache
 
-from pydantic import Field
+from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+GOOGLE_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 
 class Settings(BaseSettings):
-    app_name: str = "Kalshi Research Workflow API"
-    cors_allow_origins: list[str] = Field(default_factory=lambda: ["http://localhost:3000", "http://127.0.0.1:3000"])
-    tavily_api_key: str | None = None
-    gemini_api_key: str | None = None
-    gemini_model: str = "gemini-2.5-flash"
-    gemini_base_url: str = "https://generativelanguage.googleapis.com/v1beta"
+    app_name: str = Field(
+        default="Kalshi Research Workflow API", validation_alias=AliasChoices("WORKFLOW_APP_NAME", "APP_NAME")
+    )
+    cors_allow_origins: list[str] = Field(
+        default_factory=lambda: ["http://localhost:3000", "http://127.0.0.1:3000"],
+        validation_alias=AliasChoices("WORKFLOW_CORS_ALLOW_ORIGINS", "CORS_ALLOW_ORIGINS"),
+    )
+    tavily_api_key: str | None = Field(
+        default=None, validation_alias=AliasChoices("WORKFLOW_TAVILY_API_KEY", "TAVILY_API_KEY")
+    )
+    gemini_api_key: str | None = Field(
+        default=None, validation_alias=AliasChoices("WORKFLOW_GEMINI_API_KEY", "GEMINI_API_KEY")
+    )
+    gemini_model: str = Field(
+        default="gemini-2.5-flash", validation_alias=AliasChoices("WORKFLOW_GEMINI_MODEL", "GEMINI_MODEL")
+    )
+    gemini_base_url: str = Field(
+        default=GOOGLE_GEMINI_BASE_URL, validation_alias=AliasChoices("WORKFLOW_GEMINI_BASE_URL", "GEMINI_BASE_URL")
+    )
 
-    model_config = SettingsConfigDict(env_prefix="WORKFLOW_", env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(env_file=("../.env", ".env"), extra="ignore")
+
+    @model_validator(mode="after")
+    def infer_openrouter_settings(self) -> "Settings":
+        if self.gemini_api_key and self.gemini_api_key.startswith("sk-or-") and self.gemini_base_url == GOOGLE_GEMINI_BASE_URL:
+            self.gemini_base_url = OPENROUTER_BASE_URL
+            if "/" not in self.gemini_model:
+                self.gemini_model = f"google/{self.gemini_model}"
+        return self
 
 
 @lru_cache

--- a/workflow-python/app/fixtures/demo_response.py
+++ b/workflow-python/app/fixtures/demo_response.py
@@ -124,7 +124,8 @@ DEMO_WORKFLOW_RESPONSE: dict[str, object] = {
     ),
     "developer": {"rawJsonInspectionEnabled": True, "rawJsonLabel": "Validated workflow response JSON"},
     "disclaimer": (
-        "This is research-only analysis, not financial advice or a recommendation to buy, sell, or place any trade."
+        "This is research-only analysis, not financial advice or trading advice, and not a recommendation or "
+        "order instruction."
     ),
 }
 

--- a/workflow-python/app/orchestrator/service.py
+++ b/workflow-python/app/orchestrator/service.py
@@ -7,6 +7,8 @@ from app.contracts.workflow import (
     AgentRole,
     AgentTraceEntry,
     Evidence,
+    SettlementRisk,
+    Warning,
     WorkflowRequest,
     WorkflowResponse,
 )
@@ -14,6 +16,7 @@ from app.core.config import get_settings
 from app.core.errors import ErrorCode, WorkflowError
 from app.fixtures.demo_response import build_demo_response
 from app.tools.evidence_research import EvidenceResearchTool, EvidenceSearchResult, TavilySearchProvider
+from app.tools.gemini_probability import GeminiProbabilityTool
 from app.tools.kalshi_market_data import KalshiPublicMarketDataTool, PublicMarketData
 from app.tools.probability_scoring import ProbabilityScoringResult, score_probability
 from app.tools.settlement_risk import audit_settlement_risk
@@ -25,6 +28,19 @@ class MarketDataTool(Protocol):
 
 class ResearchTool(Protocol):
     async def gather(self, query: str, *, max_results: int = 5) -> EvidenceSearchResult: ...
+
+
+class ProbabilityTool(Protocol):
+    async def score(
+        self,
+        *,
+        market_title: str,
+        market_ticker: str,
+        kalshi_implied_probability: float,
+        evidence: list[Evidence],
+        settlement_risks: list[SettlementRisk],
+        warnings: list[Warning],
+    ) -> ProbabilityScoringResult: ...
 
 
 AGENT_SEQUENCE: tuple[tuple[AgentRole, str], ...] = (
@@ -43,10 +59,12 @@ class WorkflowService:
         *,
         market_data_tool: MarketDataTool | None = None,
         research_tool: ResearchTool | None = None,
+        probability_tool: ProbabilityTool | None = None,
         secrets: list[str] | None = None,
     ) -> None:
         self._market_data_tool = market_data_tool
         self._research_tool = research_tool
+        self._probability_tool = probability_tool
         self._secrets = [secret for secret in secrets or [] if secret]
 
     async def analyze(self, request: WorkflowRequest) -> WorkflowResponse:
@@ -69,12 +87,22 @@ class WorkflowService:
             research = await self._research_tool.gather(_research_query(market_data), max_results=5)
             trace.append(_trace(AgentRole.RESEARCH, "Gathered public evidence for the exact market criteria."))
 
-            scoring = score_probability(
-                kalshi_implied_probability=market_data.implied_probability,
-                evidence=research.evidence,
-                settlement_risks=settlement_risks,
-                warnings=market_data.warnings,
-            )
+            if self._probability_tool is None:
+                scoring = score_probability(
+                    kalshi_implied_probability=market_data.implied_probability,
+                    evidence=research.evidence,
+                    settlement_risks=settlement_risks,
+                    warnings=market_data.warnings,
+                )
+            else:
+                scoring = await self._probability_tool.score(
+                    market_title=market_data.market.title,
+                    market_ticker=market_data.market.ticker,
+                    kalshi_implied_probability=market_data.implied_probability,
+                    evidence=research.evidence,
+                    settlement_risks=settlement_risks,
+                    warnings=market_data.warnings,
+                )
             trace.append(_trace(AgentRole.PROBABILITY_ESTIMATOR, "Produced a bounded probability estimate."))
             trace.append(_trace(AgentRole.SKEPTIC, "Added counterarguments and change conditions."))
             trace.append(_trace(AgentRole.MEMO_EDITOR, "Validated strict JSON response contract."))
@@ -93,13 +121,22 @@ class WorkflowService:
 def get_workflow_service() -> WorkflowService:
     settings = get_settings()
     research_tool = None
+    probability_tool = None
     secrets = []
     if settings.tavily_api_key:
         research_tool = EvidenceResearchTool(TavilySearchProvider(settings.tavily_api_key))
         secrets.append(settings.tavily_api_key)
+    if settings.gemini_api_key:
+        probability_tool = GeminiProbabilityTool(
+            settings.gemini_api_key,
+            model=settings.gemini_model,
+            base_url=settings.gemini_base_url,
+        )
+        secrets.append(settings.gemini_api_key)
     return WorkflowService(
         market_data_tool=KalshiPublicMarketDataTool(),
         research_tool=research_tool,
+        probability_tool=probability_tool,
         secrets=secrets,
     )
 

--- a/workflow-python/app/orchestrator/service.py
+++ b/workflow-python/app/orchestrator/service.py
@@ -147,8 +147,8 @@ def _response_payload(
         "finalMemoMarkdown": _memo_markdown(market_data, scoring),
         "developer": {"rawJsonInspectionEnabled": True, "rawJsonLabel": "Validated workflow response JSON"},
         "disclaimer": (
-            "This is research-only analysis, not financial advice or a recommendation to buy, sell, or place any "
-            "trade."
+            "This is research-only analysis, not financial advice or trading advice, and not a recommendation or order "
+            "instruction."
         ),
     }
 

--- a/workflow-python/app/tools/gemini_probability.py
+++ b/workflow-python/app/tools/gemini_probability.py
@@ -1,0 +1,182 @@
+import json
+from typing import Any
+
+import httpx
+
+from app.contracts.workflow import BoundedLevel, Delta, Evidence, SettlementRisk, Warning
+from app.core.errors import ErrorCode, WorkflowError
+from app.tools.probability_scoring import ProbabilityScoringResult, score_probability
+
+GEMINI_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+
+
+class GeminiProbabilityTool:
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        model: str = "gemini-2.5-flash",
+        base_url: str = GEMINI_API_BASE_URL,
+        timeout_seconds: float = 30,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._api_key = api_key.strip()
+        self._model = model.strip()
+        self._base_url = base_url.rstrip("/")
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    async def score(
+        self,
+        *,
+        market_title: str,
+        market_ticker: str,
+        kalshi_implied_probability: float,
+        evidence: list[Evidence],
+        settlement_risks: list[SettlementRisk],
+        warnings: list[Warning],
+    ) -> ProbabilityScoringResult:
+        if not self._api_key:
+            raise WorkflowError(
+                ErrorCode.MODEL_FAILURE, "Gemini API key is required for live scoring.", status_code=503
+            )
+
+        prompt = _prompt(
+            market_title=market_title,
+            market_ticker=market_ticker,
+            kalshi_implied_probability=kalshi_implied_probability,
+            evidence=evidence,
+            settlement_risks=settlement_risks,
+            warnings=warnings,
+        )
+        async with httpx.AsyncClient(timeout=self._timeout_seconds, transport=self._transport) as client:
+            try:
+                response = await self._post_model_request(client, prompt)
+                response.raise_for_status()
+                payload = response.json()
+            except (httpx.HTTPError, ValueError) as exc:
+                raise WorkflowError(ErrorCode.MODEL_FAILURE, "Gemini scoring failed.", status_code=502) from exc
+
+        try:
+            parsed = json.loads(_candidate_text(payload))
+            probability = float(parsed["probability"])
+            probability_points = probability - kalshi_implied_probability
+            return score_probability(
+                kalshi_implied_probability=kalshi_implied_probability,
+                evidence=evidence,
+                settlement_risks=settlement_risks,
+                counterarguments=parsed["counterarguments"],
+                warnings=warnings,
+            ).model_copy(
+                update={
+                    "probability": probability,
+                    "confidence": BoundedLevel(parsed["confidence"]),
+                    "thesis": parsed["thesis"],
+                    "assumptions": parsed["assumptions"],
+                    "delta": Delta(probability_points=probability_points, direction=_direction(probability_points)),
+                    "what_would_change": parsed["whatWouldChange"],
+                }
+            )
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise WorkflowError(
+                ErrorCode.MODEL_FAILURE, "Gemini returned invalid scoring JSON.", status_code=502
+            ) from exc
+
+    async def _post_model_request(self, client: httpx.AsyncClient, prompt: str) -> httpx.Response:
+        if _is_openai_compatible(self._base_url):
+            return await client.post(
+                f"{self._base_url}/chat/completions",
+                headers={"Authorization": f"Bearer {self._api_key}"},
+                json={
+                    "model": self._model,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "response_format": {
+                        "type": "json_schema",
+                        "json_schema": {"name": "probability", "schema": _response_schema()},
+                    },
+                    "max_tokens": 1024,
+                },
+            )
+
+        return await client.post(
+            f"{self._base_url}/models/{self._model}:generateContent",
+            params={"key": self._api_key},
+            json={
+                "contents": [{"role": "user", "parts": [{"text": prompt}]}],
+                "generationConfig": {
+                    "responseMimeType": "application/json",
+                    "responseJsonSchema": _response_schema(),
+                },
+            },
+        )
+
+
+def _prompt(
+    *,
+    market_title: str,
+    market_ticker: str,
+    kalshi_implied_probability: float,
+    evidence: list[Evidence],
+    settlement_risks: list[SettlementRisk],
+    warnings: list[Warning],
+) -> str:
+    return json.dumps(
+        {
+            "instruction": (
+                "Produce research-only probability analysis for a Kalshi market. Do not recommend buying, selling, "
+                "placing trades, or taking positions. Return only JSON matching the schema."
+            ),
+            "market": {"ticker": market_ticker, "title": market_title},
+            "kalshiImpliedProbability": kalshi_implied_probability,
+            "evidence": [item.model_dump(mode="json") for item in evidence],
+            "settlementRisks": [item.model_dump(mode="json") for item in settlement_risks],
+            "warnings": [item.model_dump(mode="json") for item in warnings],
+        }
+    )
+
+
+def _response_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "probability": {"type": "number", "minimum": 0, "maximum": 1},
+            "confidence": {"type": "string", "enum": ["low", "medium", "high"]},
+            "thesis": {"type": "string"},
+            "assumptions": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "counterarguments": {"type": "array", "items": {"type": "string"}},
+            "whatWouldChange": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+        },
+        "required": ["probability", "confidence", "thesis", "assumptions", "counterarguments", "whatWouldChange"],
+        "propertyOrdering": [
+            "probability",
+            "confidence",
+            "thesis",
+            "assumptions",
+            "counterarguments",
+            "whatWouldChange",
+        ],
+    }
+
+
+def _candidate_text(payload: Any) -> str:
+    if isinstance(payload, dict) and "choices" in payload:
+        text = payload["choices"][0]["message"]["content"]
+        if not isinstance(text, str):
+            raise ValueError("OpenAI-compatible response did not include text.")
+        return text
+
+    candidates = payload["candidates"]
+    text = candidates[0]["content"]["parts"][0]["text"]
+    if not isinstance(text, str):
+        raise ValueError("Gemini response did not include text.")
+    return text
+
+
+def _is_openai_compatible(base_url: str) -> bool:
+    return "openrouter.ai" in base_url or base_url.rstrip("/").endswith("/v1")
+
+
+def _direction(probability_points: float) -> str:
+    if abs(probability_points) <= 0.000001:
+        return "in_line"
+    return "agent_higher" if probability_points > 0 else "agent_lower"

--- a/workflow-python/app/tools/gemini_probability.py
+++ b/workflow-python/app/tools/gemini_probability.py
@@ -40,6 +40,12 @@ class GeminiProbabilityTool:
             raise WorkflowError(
                 ErrorCode.MODEL_FAILURE, "Gemini API key is required for live scoring.", status_code=503
             )
+        if self._api_key.startswith("sk-or-") and not _is_openai_compatible(self._base_url):
+            raise WorkflowError(
+                ErrorCode.MODEL_FAILURE,
+                "OpenRouter API keys require WORKFLOW_GEMINI_BASE_URL=https://openrouter.ai/api/v1.",
+                status_code=503,
+            )
 
         prompt = _prompt(
             market_title=market_title,
@@ -100,7 +106,7 @@ class GeminiProbabilityTool:
 
         return await client.post(
             f"{self._base_url}/models/{self._model}:generateContent",
-            params={"key": self._api_key},
+            headers={"x-goog-api-key": self._api_key},
             json={
                 "contents": [{"role": "user", "parts": [{"text": prompt}]}],
                 "generationConfig": {

--- a/workflow-python/tests/test_analyze.py
+++ b/workflow-python/tests/test_analyze.py
@@ -1,5 +1,7 @@
 from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
 
+from app.core.config import get_settings
 from app.main import create_app
 
 
@@ -44,7 +46,10 @@ def test_analyze_rejects_missing_market_input() -> None:
     assert response.json()["code"] == "invalid_input"
 
 
-def test_analyze_returns_typed_error_when_live_workflow_unavailable() -> None:
+def test_analyze_returns_typed_error_when_live_workflow_unavailable(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("WORKFLOW_TAVILY_API_KEY", "")
+    monkeypatch.setenv("WORKFLOW_GEMINI_API_KEY", "")
+    get_settings.cache_clear()
     client = TestClient(create_app())
 
     response = client.post("/analyze", json={"marketInput": "KXEXAMPLE-26MAY03-DEMO", "demoMode": False})
@@ -53,3 +58,4 @@ def test_analyze_returns_typed_error_when_live_workflow_unavailable() -> None:
     payload = response.json()
     assert payload["code"] == "workflow_unavailable"
     assert payload["request_id"]
+    get_settings.cache_clear()

--- a/workflow-python/tests/test_config.py
+++ b/workflow-python/tests/test_config.py
@@ -1,0 +1,29 @@
+from app.core.config import OPENROUTER_BASE_URL, Settings
+
+
+def test_settings_accept_unprefixed_local_env_aliases(monkeypatch) -> None:
+    monkeypatch.setenv("GEMINI_API_KEY", "google-key")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
+
+    settings = Settings()
+
+    assert settings.gemini_api_key == "google-key"
+    assert settings.tavily_api_key == "tavily-key"
+
+
+def test_settings_infer_openrouter_for_openrouter_key(monkeypatch) -> None:
+    monkeypatch.setenv("GEMINI_API_KEY", "sk-or-test")
+
+    settings = Settings()
+
+    assert settings.gemini_base_url == OPENROUTER_BASE_URL
+    assert settings.gemini_model == "google/gemini-2.5-flash"
+
+
+def test_workflow_prefixed_settings_take_precedence(monkeypatch) -> None:
+    monkeypatch.setenv("GEMINI_API_KEY", "google-key")
+    monkeypatch.setenv("WORKFLOW_GEMINI_API_KEY", "workflow-google-key")
+
+    settings = Settings()
+
+    assert settings.gemini_api_key == "workflow-google-key"

--- a/workflow-python/tests/test_contracts.py
+++ b/workflow-python/tests/test_contracts.py
@@ -64,3 +64,19 @@ def test_response_contract_rejects_trading_advice_disclaimer() -> None:
 
     with pytest.raises(ValidationError, match="Disclaimer"):
         WorkflowResponse.model_validate(payload)
+
+
+def test_response_contract_rejects_direct_buy_recommendation_output() -> None:
+    payload = copy.deepcopy(DEMO_WORKFLOW_RESPONSE)
+    payload["finalMemoMarkdown"] = "## Research Memo\n\nYou should buy this market now."
+
+    with pytest.raises(ValidationError, match="recommendation"):
+        WorkflowResponse.model_validate(payload)
+
+
+def test_response_contract_rejects_direct_sell_recommendation_output() -> None:
+    payload = copy.deepcopy(DEMO_WORKFLOW_RESPONSE)
+    payload["finalMemoMarkdown"] = "## Research Memo\n\nWe recommend sell based on this evidence."
+
+    with pytest.raises(ValidationError, match="recommendation"):
+        WorkflowResponse.model_validate(payload)

--- a/workflow-python/tests/test_gemini_probability.py
+++ b/workflow-python/tests/test_gemini_probability.py
@@ -1,0 +1,66 @@
+import httpx
+import pytest
+
+from app.contracts.workflow import BoundedLevel
+from app.core.errors import ErrorCode, WorkflowError
+from app.tools.gemini_probability import GeminiProbabilityTool
+
+
+@pytest.mark.asyncio
+async def test_openrouter_key_requires_openai_compatible_base_url() -> None:
+    tool = GeminiProbabilityTool("sk-or-test")
+
+    with pytest.raises(WorkflowError) as error:
+        await tool.score(
+            market_title="Example market",
+            market_ticker="KXEXAMPLE-26",
+            kalshi_implied_probability=0.5,
+            evidence=[],
+            settlement_risks=[],
+            warnings=[],
+        )
+
+    assert error.value.code == ErrorCode.MODEL_FAILURE
+    assert error.value.status_code == 503
+    assert "OpenRouter API keys require" in error.value.message
+
+
+@pytest.mark.asyncio
+async def test_google_gemini_key_is_sent_in_header_not_url() -> None:
+    captured_request: httpx.Request | None = None
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal captured_request
+        captured_request = request
+        return httpx.Response(
+            200,
+            json={
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {
+                                    "text": '{"probability":0.55,"confidence":"medium","thesis":"Balanced case.","assumptions":["Court timing remains unchanged."],"counterarguments":[],"whatWouldChange":["New docket activity."]}'
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+        )
+
+    tool = GeminiProbabilityTool("google-key", transport=httpx.MockTransport(handler))
+
+    result = await tool.score(
+        market_title="Example market",
+        market_ticker="KXEXAMPLE-26",
+        kalshi_implied_probability=0.5,
+        evidence=[],
+        settlement_risks=[],
+        warnings=[],
+    )
+
+    assert result.confidence == BoundedLevel.MEDIUM
+    assert captured_request is not None
+    assert captured_request.url.params.get("key") is None
+    assert captured_request.headers["x-goog-api-key"] == "google-key"

--- a/workflow-python/tests/test_settlement_risk.py
+++ b/workflow-python/tests/test_settlement_risk.py
@@ -82,9 +82,9 @@ def _market_data(
             closeTime=close_time,
             settlementSource=settlement_source,
         ),
-        impliedProbability=0.5,
-        prices=PriceContext(yesBid=0.48, yesAsk=0.52, lastPrice=0.5, spread=0.04),
+        implied_probability=0.5,
+        prices=PriceContext(yes_bid=0.48, yes_ask=0.52, last_price=0.5, spread=0.04),
         volume=1000,
-        openInterest=500,
+        open_interest=500,
         warnings=[],
     )


### PR DESCRIPTION
## Summary
- Normalize Kalshi ticker and market URL input before submission and call the configured browser-safe workflow endpoint.
- Validate live workflow responses before rendering, map workflow failure codes to explicit UI states, and keep demo fallback opt-in.
- Harden research-only safety checks across TypeScript and Python contracts so direct recommendation phrasing is rejected.

## Verification
- npm run typecheck
- npm run lint
- npm run test
- npm run build
- cd workflow-python && uv run ruff check . && uv run mypy app tests && uv run pytest

Closes #4
Closes #10
Closes #11