### PR TITLE
Fix Kalshi event ticker market resolution

### DIFF
--- a/components/research-memo.tsx
+++ b/components/research-memo.tsx
@@ -110,95 +110,22 @@ function ProbabilityComparison({ response }: Props) {
 
   return (
     <Section eyebrow="01" title="Probability comparison" data-testid="probability-comparison">
-      <div className="bg-card ring-foreground/10 overflow-hidden rounded-xl ring-1">
-        <div className="divide-border grid grid-cols-1 divide-y sm:grid-cols-3 sm:divide-x sm:divide-y-0">
-          <Stat label="Kalshi implied" value={formatProbability(kalshi)} />
-          <Stat label="Agent estimate" value={formatProbability(agent)} emphasized />
-          <Stat
-            label={directionLabel[response.delta.direction]}
-            value={
-              <span className="inline-flex items-baseline gap-1.5">
-                <span aria-hidden className="text-foreground/60 text-2xl leading-none">
-                  {directionGlyph[response.delta.direction]}
-                </span>
-                <span>{formatDeltaPoints(deltaPoints)}</span>
+      <div className="grid grid-cols-1 gap-x-10 gap-y-6 sm:grid-cols-3">
+        <Stat label="Kalshi implied" value={formatProbability(kalshi)} />
+        <Stat label="Agent estimate" value={formatProbability(agent)} emphasized />
+        <Stat
+          label={directionLabel[response.delta.direction]}
+          value={
+            <span className="inline-flex items-baseline gap-1.5">
+              <span aria-hidden className="text-foreground/60 text-2xl leading-none">
+                {directionGlyph[response.delta.direction]}
               </span>
-            }
-          />
-        </div>
-        <Separator />
-        <ProbabilityTrack kalshi={kalshi} agent={agent} />
+              <span>{formatDeltaPoints(deltaPoints)}</span>
+            </span>
+          }
+        />
       </div>
-
-      {response.kalshi.spread !== undefined ||
-      response.kalshi.volume !== undefined ||
-      response.kalshi.openInterest !== undefined ? (
-        <dl className="text-muted-foreground mt-4 grid grid-cols-2 gap-x-8 gap-y-2 text-xs sm:grid-cols-4">
-          {response.kalshi.yesBid !== undefined ? (
-            <MetaRow label="Yes bid" value={formatProbability(response.kalshi.yesBid)} />
-          ) : null}
-          {response.kalshi.yesAsk !== undefined ? (
-            <MetaRow label="Yes ask" value={formatProbability(response.kalshi.yesAsk)} />
-          ) : null}
-          {response.kalshi.spread !== undefined ? (
-            <MetaRow label="Spread" value={formatProbability(response.kalshi.spread)} />
-          ) : null}
-          {response.kalshi.volume !== undefined ? (
-            <MetaRow label="Volume" value={response.kalshi.volume.toLocaleString()} />
-          ) : null}
-        </dl>
-      ) : null}
     </Section>
-  );
-}
-
-function ProbabilityTrack({ kalshi, agent }: { kalshi: number; agent: number }) {
-  return (
-    <div className="px-6 py-5">
-      <div className="text-muted-foreground mb-3 flex justify-between text-[0.7rem] tracking-wide uppercase">
-        <span>0%</span>
-        <span>50%</span>
-        <span>100%</span>
-      </div>
-      <div className="bg-muted relative h-1.5 w-full rounded-full">
-        <Marker position={kalshi} variant="kalshi" label="Kalshi" />
-        <Marker position={agent} variant="agent" label="Agent" />
-      </div>
-      <div className="mt-3 flex items-center gap-4 text-xs">
-        <span className="text-muted-foreground inline-flex items-center gap-1.5">
-          <span aria-hidden className="bg-foreground/40 size-2 rounded-full" />
-          Kalshi {formatProbability(kalshi)}
-        </span>
-        <span className="text-muted-foreground inline-flex items-center gap-1.5">
-          <span aria-hidden className="bg-foreground size-2 rounded-sm" />
-          Agent {formatProbability(agent)}
-        </span>
-      </div>
-    </div>
-  );
-}
-
-function Marker({
-  position,
-  variant,
-  label,
-}: {
-  position: number;
-  variant: "kalshi" | "agent";
-  label: string;
-}) {
-  const left = `${Math.max(0, Math.min(1, position)) * 100}%`;
-  return (
-    <span
-      aria-label={`${label} ${formatProbability(position)}`}
-      className={cn(
-        "absolute top-1/2 -translate-x-1/2 -translate-y-1/2",
-        variant === "agent"
-          ? "bg-foreground size-3 rounded-sm"
-          : "bg-foreground/40 ring-background size-2.5 rounded-full ring-2",
-      )}
-      style={{ left }}
-    />
   );
 }
 
@@ -212,7 +139,7 @@ function Stat({
   emphasized?: boolean;
 }) {
   return (
-    <div className="flex flex-col gap-1.5 px-6 py-5">
+    <div className="flex flex-col gap-2">
       <span className="text-muted-foreground text-[0.7rem] tracking-wide uppercase">{label}</span>
       <span
         className={cn(

--- a/workflow-python/app/tools/kalshi_market_data.py
+++ b/workflow-python/app/tools/kalshi_market_data.py
@@ -79,14 +79,14 @@ class KalshiPublicMarketDataTool:
         async with httpx.AsyncClient(
             base_url=self._base_url, timeout=self._timeout_seconds, transport=self._transport
         ) as client:
-            market_payload = await self._get_json(client, f"/markets/{normalized_ticker}")
-            orderbook_payload = await self._get_optional_json(client, f"/markets/{normalized_ticker}/orderbook")
-
-        market = market_payload.get("market", market_payload)
-        if not isinstance(market, dict):
-            raise WorkflowError(
-                ErrorCode.MARKET_DATA_UNAVAILABLE, "Kalshi market response was malformed.", status_code=502
-            )
+            market_payload = await self._get_market_or_event_json(client, normalized_ticker)
+            market = market_payload.get("market", market_payload)
+            if not isinstance(market, dict):
+                raise WorkflowError(
+                    ErrorCode.MARKET_DATA_UNAVAILABLE, "Kalshi market response was malformed.", status_code=502
+                )
+            resolved_ticker = str(market.get("ticker") or normalized_ticker)
+            orderbook_payload = await self._get_optional_json(client, f"/markets/{resolved_ticker}/orderbook")
 
         orderbook = _summarize_orderbook(orderbook_payload)
         prices = _price_context(market)
@@ -113,6 +113,18 @@ class KalshiPublicMarketDataTool:
             orderbook=orderbook,
             warnings=warnings,
         )
+
+    async def _get_market_or_event_json(self, client: httpx.AsyncClient, ticker: str) -> dict[str, Any]:
+        try:
+            return await self._get_json(client, f"/markets/{ticker}")
+        except WorkflowError as market_error:
+            event_payload = await self._get_optional_json(client, f"/events/{ticker}")
+            if event_payload is None:
+                raise market_error
+            market = _representative_event_market(event_payload)
+            if market is None:
+                raise market_error
+            return {"market": market}
 
     async def _get_json(self, client: httpx.AsyncClient, path: str) -> dict[str, Any]:
         try:
@@ -143,6 +155,26 @@ def _price_context(market: dict[str, Any]) -> PriceContext:
     raw_spread = yes_ask - yes_bid if yes_bid is not None and yes_ask is not None else None
     spread = raw_spread if raw_spread is None or raw_spread >= 0 else None
     return PriceContext(yesBid=yes_bid, yesAsk=yes_ask, lastPrice=last_price, spread=spread)
+
+
+def _representative_event_market(payload: dict[str, Any]) -> dict[str, Any] | None:
+    markets = payload.get("markets")
+    if not isinstance(markets, list):
+        return None
+    candidates = [market for market in markets if isinstance(market, dict)]
+    if not candidates:
+        return None
+    open_markets = [market for market in candidates if _status(market.get("status")) == "open"]
+    return max(open_markets or candidates, key=_market_liquidity_score)
+
+
+def _market_liquidity_score(market: dict[str, Any]) -> Decimal:
+    scores = [
+        _fixed_point_count(market.get("volume_24h_fp")),
+        _fixed_point_count(market.get("volume_fp") or market.get("volume")),
+        _fixed_point_count(market.get("open_interest_fp") or market.get("open_interest")),
+    ]
+    return sum((score for score in scores if score is not None), Decimal("0"))
 
 
 def _implied_probability(prices: PriceContext) -> float:

--- a/workflow-python/tests/test_kalshi_market_data.py
+++ b/workflow-python/tests/test_kalshi_market_data.py
@@ -97,6 +97,43 @@ async def test_missing_orderbook_data_does_not_crash_and_warns() -> None:
 
 
 @pytest.mark.asyncio
+async def test_event_ticker_resolves_to_most_liquid_child_market() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/markets/KXNEXTAG-29":
+            return httpx.Response(404, json={"error": {"code": "not_found"}})
+        if request.url.path == "/events/KXNEXTAG-29":
+            return httpx.Response(
+                200,
+                json={
+                    "event": {"event_ticker": "KXNEXTAG-29", "title": "Who will be next AG?"},
+                    "markets": [
+                        _market(
+                            ticker="KXNEXTAG-29-LZEL", subtitle=None, yes_sub_title="Lee Zeldin", volume_24h_fp="10.00"
+                        )[
+                            "market"
+                        ],
+                        _market(
+                            ticker="KXNEXTAG-29-TBLA", subtitle=None, yes_sub_title="Todd Blanche", volume_24h_fp="100.00"
+                        )[
+                            "market"
+                        ],
+                    ],
+                },
+            )
+        if request.url.path == "/markets/KXNEXTAG-29-TBLA/orderbook":
+            return httpx.Response(200, json=_orderbook())
+        return httpx.Response(404, json={"error": {"code": "not_found"}})
+
+    tool = KalshiPublicMarketDataTool(base_url="https://kalshi.test", transport=httpx.MockTransport(handler))
+
+    result = await tool.fetch("KXNEXTAG-29", now=datetime(2026, 5, 3, tzinfo=UTC))
+
+    assert result.market.ticker == "KXNEXTAG-29-TBLA"
+    assert result.market.subtitle == "Todd Blanche"
+    assert result.implied_probability == 0.44
+
+
+@pytest.mark.asyncio
 async def test_thin_liquidity_warning_uses_volume_and_top_of_book() -> None:
     tool, _requests = _tool(
         {


### PR DESCRIPTION
## Summary
- Resolve Kalshi event tickers by falling back to the event endpoint and selecting the most liquid child market.
- Fetch orderbook data using the resolved child market ticker.
- Keep the probability comparison UI simplified from the uncommitted changes.

## Tests
- uv run pytest tests/test_kalshi_market_data.py
- npm run typecheck
- npm run lint