### PR TITLE
Make loader pulse dots use primary green

### DIFF
--- a/components/loading-view.tsx
+++ b/components/loading-view.tsx
@@ -30,7 +30,7 @@ export function LoadingView({ marketInput }: Props) {
               key={agent.role}
               className="border-border flex items-center gap-3 border-b px-4 py-3 last:border-b-0"
             >
-              <span aria-hidden className="bg-emerald-300 size-2 shrink-0 animate-pulse rounded-full" />
+              <span aria-hidden className="bg-primary size-2 shrink-0 animate-pulse rounded-full" />
               <div className="flex flex-1 flex-col gap-0.5">
                 <span className="text-foreground text-sm font-medium">{agent.name}</span>
                 <span className="text-muted-foreground text-xs">{agent.note}</span>

--- a/components/loading-view.tsx
+++ b/components/loading-view.tsx
@@ -30,7 +30,7 @@ export function LoadingView({ marketInput }: Props) {
               key={agent.role}
               className="border-border flex items-center gap-3 border-b px-4 py-3 last:border-b-0"
             >
-              <span aria-hidden className="bg-primary size-2 shrink-0 animate-pulse rounded-full" />
+              <span aria-hidden className="bg-emerald-300 size-2 shrink-0 animate-pulse rounded-full" />
               <div className="flex flex-1 flex-col gap-0.5">
                 <span className="text-foreground text-sm font-medium">{agent.name}</span>
                 <span className="text-muted-foreground text-xs">{agent.note}</span>

--- a/components/loading-view.tsx
+++ b/components/loading-view.tsx
@@ -30,7 +30,7 @@ export function LoadingView({ marketInput }: Props) {
               key={agent.role}
               className="border-border flex items-center gap-3 border-b px-4 py-3 last:border-b-0"
             >
-              <span aria-hidden className="bg-muted-foreground size-2 shrink-0 animate-pulse rounded-full" />
+              <span aria-hidden className="bg-primary size-2 shrink-0 animate-pulse rounded-full" />
               <div className="flex flex-1 flex-col gap-0.5">
                 <span className="text-foreground text-sm font-medium">{agent.name}</span>
                 <span className="text-muted-foreground text-xs">{agent.note}</span>


### PR DESCRIPTION
## Summary
- Changes the agent loader pulse dots in `components/loading-view.tsx` from `bg-muted-foreground` (gray) to `bg-primary` so they pick up the teal-green brand color used on the main page (e.g. the "seconds" accent).

## Test plan
- [ ] Trigger a research run and confirm the six pulsing dots in the loading view render in the brand green.