### PR TITLE
Match Kalshi/Agent lower font size to Agent estimate

### DIFF
--- a/components/research-memo.tsx
+++ b/components/research-memo.tsx
@@ -146,9 +146,8 @@ function Stat({
       <span
         className={cn(
           "tabular-nums",
-          emphasized
-            ? "text-primary text-[2.5rem] leading-none font-semibold tracking-tight"
-            : "text-foreground text-[1.75rem] leading-none font-semibold tracking-tight",
+          "text-[2.5rem] leading-none font-semibold tracking-tight",
+          emphasized ? "text-primary" : "text-foreground",
         )}
       >
         {value}


### PR DESCRIPTION
## Summary
- Unifies the font size of all three stats in the Probability comparison section so Kalshi implied and Agent lower match the Agent estimate (2.5rem).
- Color emphasis (text-primary vs text-foreground) is preserved.

## Test plan
- [ ] Visually confirm Probability comparison row in the research memo renders all three numbers at the same size.