### PR TITLE
Close spec 001: deploys verified live

### DIFF
--- a/docs/agents/friction-log.md
+++ b/docs/agents/friction-log.md
@@ -36,3 +36,4 @@ One line per observation, newest last:
 
 - 2026-07-18 | live engine verification | The stored GEMINI_API_KEY (OpenRouter sk-or-…) returns 401 on chat completions, so live runs silently need the heuristic-scoring fallback; nothing documented the key's health | keep a working estimator key in .env or note the fallback in README
 - 2026-07-18 | VPS public exposure | Ports 80/443 are closed at the Hetzner Cloud firewall (not ufw), and neither hcloud nor Porkbun credentials are available to agents, so public HTTPS ends at ACME retries until the owner opens the firewall | document the cloud-firewall gate and credential boundaries in the hetzner-vps ops repo
+- 2026-07-18 | Cloudflare Pages deploy | New Pages projects get a random suffix on the pages.dev subdomain (`probable-9mr` -> `probable-9mr-azu.pages.dev`), so a CORS origin pinned before the first deploy is guaranteed stale | create the Pages project and read its real domain before wiring CORS

--- a/docs/work/predictor/001-probability-engine-refactor/tickets.json
+++ b/docs/work/predictor/001-probability-engine-refactor/tickets.json
@@ -2,7 +2,7 @@
   "updated_at": "2026-07-18",
   "spec": "001",
   "active_ticket": null,
-  "next_ticket": "004",
+  "next_ticket": null,
   "tickets": [
     {
       "id": "001",
@@ -29,14 +29,14 @@
       "id": "004",
       "title": "Backend deploy on Hetzner VPS",
       "file": "tickets/004-hetzner-backend-deploy.md",
-      "status": "ready-for-human",
+      "status": "completed",
       "blocked_by": ["002"]
     },
     {
       "id": "005",
       "title": "Frontend deploy on Cloudflare",
       "file": "tickets/005-cloudflare-frontend-deploy.md",
-      "status": "ready-for-human",
+      "status": "completed",
       "blocked_by": ["003", "004"]
     }
   ]

--- a/docs/work/predictor/001-probability-engine-refactor/tickets/004-hetzner-backend-deploy.md
+++ b/docs/work/predictor/001-probability-engine-refactor/tickets/004-hetzner-backend-deploy.md
@@ -19,19 +19,16 @@ project.
 
 ## Outcome
 
-Deployed 2026-07-18 as ops-repo project `projects/probable` (branch
+Completed 2026-07-18 as ops-repo project `projects/probable` (branch
 `probable-project`, ADR-008): stateless engine container built on the VPS from
-the app repo checkout, healthy on loopback `127.0.0.1:8100`; Caddy installed
-as host ingress with routes for `probable-api.gerts.io` and
-`probable-api.5-161-180-27.sslip.io` (SSE unbuffered). Engine runs without a
-Gemini key (heuristic scoring) because the stored OpenRouter key returns 401.
+the app repo checkout at `origin/main`, healthy on loopback `127.0.0.1:8100`;
+Caddy is host ingress with SSE unbuffered. TCP 80/443 opened in the Hetzner
+Cloud firewall (`vps-fw-ash`, via hcloud), Let's Encrypt cert issued for
+`https://probable-api.5-161-180-27.sslip.io`, and public health + live
+analysis streams verified end to end. A working Gemini key is in the VPS
+`.env`, so live runs use Gemini scoring (validated with a direct API call and
+a full non-demo analysis).
 
-## Remaining (human gate)
-
-- Open TCP 80 + 443 in the Hetzner Cloud firewall (console or hcloud CLI; no
-  API token available to agents). Caddy's ACME retries will then issue certs
-  automatically — no further server action needed.
-- Optional: add Porkbun A record `probable-api.gerts.io -> 5.161.180.27`.
-- Optional: put a working `GEMINI_API_KEY` into the VPS `.env` and redeploy.
-- After the integration PR merges to main, set `PROBABLE_GIT_REF=origin/main`
-  in the VPS `.env` (currently pinned to the staging branch).
+Deferred until a website exists on `gerts.io`: the Porkbun A record
+`probable-api.gerts.io -> 5.161.180.27`. The Caddy route is already in place;
+its ACME attempts fail harmlessly until the record lands.

--- a/docs/work/predictor/001-probability-engine-refactor/tickets/005-cloudflare-frontend-deploy.md
+++ b/docs/work/predictor/001-probability-engine-refactor/tickets/005-cloudflare-frontend-deploy.md
@@ -14,15 +14,14 @@ Serve the built SPA from Cloudflare, pointed at the VPS backend.
 
 ## Outcome
 
-Prepared 2026-07-18: `.env.production` pins `VITE_API_BASE_URL` to the sslip
-backend host and `npm run deploy` builds and pushes `dist/` to Cloudflare
-Pages project `probable`. The VPS engine already allowlists
-`https://probable.pages.dev` for CORS.
+Completed 2026-07-18: Cloudflare Pages project `probable-9mr` created and
+`npm run deploy` ships `dist/` to it. Cloudflare appended a random suffix to
+the subdomain, so the live origin is `https://probable-9mr-azu.pages.dev`
+(not `probable-9mr.pages.dev`); the VPS CORS allowlist and preview-origin
+regex were updated to match. Verified end to end: the site serves the built
+SPA whose bundle points at `https://probable-api.5-161-180-27.sslip.io`, and
+a CORS preflight from the deployed origin passes against the backend, which
+streams both demo and live analyses.
 
-## Remaining (human gate)
-
-- Authenticate once: `npx wrangler login`, then run `npm run deploy`.
-- If the Pages project name `probable` is taken, pick another and update the
-  CORS origin in the VPS `.env` to match.
-- After the backend moves to `probable-api.gerts.io`, update
-  `.env.production` and redeploy.
+Remaining follow-up: once the `probable-api.gerts.io` record lands, update
+`.env.production` and redeploy.

--- a/docs/work/predictor/specs.json
+++ b/docs/work/predictor/specs.json
@@ -11,14 +11,14 @@
     "cancelled",
     "archived"
   ],
-  "active_spec": "001",
+  "active_spec": null,
   "next_spec": null,
   "specs": [
     {
       "id": "001",
       "title": "Probability engine refactor and first deploy",
       "file": "001-probability-engine-refactor/spec.md",
-      "status": "active"
+      "status": "completed"
     }
   ]
 }


### PR DESCRIPTION
Closes out spec 001 (probability engine refactor and first deploy) in the tracker.

Both remaining tickets landed today:

- **004 Hetzner backend**: opened TCP 80/443 in the Hetzner Cloud firewall via hcloud; Let's Encrypt cert issued for `probable-api.5-161-180-27.sslip.io`; engine redeployed from `origin/main` with a working Gemini key (live scoring verified with a real market analysis). The `probable-api.gerts.io` record stays deferred until the site exists.
- **005 Cloudflare frontend**: Pages project `probable-9mr` created and deployed; live origin is `https://probable-9mr-azu.pages.dev` (Cloudflare appends a random subdomain suffix), VPS CORS updated to match; end-to-end demo and live streams verified from the deployed origin.

Docs-only change: ticket outcomes, tracker statuses (spec 001 completed), one friction-log entry about the Pages subdomain suffix.